### PR TITLE
typo fix, HIP-1

### DIFF
--- a/HIP/hip-1.md
+++ b/HIP/hip-1.md
@@ -288,7 +288,7 @@ Editors don’t pass judgement on the HIPs. We merely do the administrative & ed
 
 ## Style Guide
 
-When referring to a HIP by number, it should be written in the hyphenated form HIP-X where X i
+When referring to a HIP by number, it should be written in the hyphenated form HIP-X where X is the HIP number.
 
 ## History
 


### PR DESCRIPTION
typo fix: the last few words of a sentence were missing.

**Description**:
Typo fix: the last few words of a sentence were missing.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
