### PR TITLE
Update hip-13.md

### DIFF
--- a/HIP/hip-13.md
+++ b/HIP/hip-13.md
@@ -3,9 +3,10 @@ hip: 13
 title: Hedera Name Service
 author: H. Bart <hbart.lit@gmail.com>
 type: Standards Track
-category: Service
-needs-council-approval: Yes
-status: Draft
+category: Application
+needs-council-approval: No
+status: Last Call
+last-call-date-time: 2021-11-23 07:00:00 UTC
 created: 2021-03-13
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/56
 updated: 2021-05-12

--- a/HIP/hip-13.md
+++ b/HIP/hip-13.md
@@ -6,7 +6,7 @@ type: Standards Track
 category: Application
 needs-council-approval: No
 status: Last Call
-last-call-date-time: 2021-11-23 07:00:00 UTC
+last-call-date-time: 2021-11-23T07:00:00Z
 created: 2021-03-13
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/56
 updated: 2021-05-12


### PR DESCRIPTION
- Recategorized HIP-13 to `Application` category
- Updated to the `Last Call` status
- Updated `needs-council-approval` to `No` (Application HIPs normally don't require council approval)

Signed-off-by: Serg Metelin <sergey.metelin@hedera.com>