### PR TITLE
Update hip-20.md

### DIFF
--- a/HIP/hip-20.md
+++ b/HIP/hip-20.md
@@ -5,7 +5,8 @@ author: Khoa Luong <khoa.luong@luthersystems.com>, Sam Wood <sam.wood@luthersyst
 type: Standards Track
 category: Service
 needs-council-approval: Yes
-status: Draft
+status: Replaced
+superseded-by: 30
 created: 2021-06-29
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/110
 ---


### PR DESCRIPTION
- As per https://github.com/hashgraph/hedera-improvement-proposal/discussions/110#discussioncomment-1633069 - this HIP is superseded by HIP-30

Signed-off-by: Serg Metelin <sergey.metelin@hedera.com>