### PR TITLE
Update hip-14.md

### DIFF
--- a/HIP/hip-14.md
+++ b/HIP/hip-14.md
@@ -5,10 +5,11 @@ author: Fernando Paris <fer@io.builders>, Fernando Paris <@ferparishuertas>
 type: Standards Track
 category: Service
 needs-council-approval: Yes
-status: Draft
+superseded-by: 24
+status: Replaced
 created: 2021-03-24
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/59
-updated: 2021-05-12
+updated: 2021-05-12, 2021-11-30
 ---
 
 ## Abstract


### PR DESCRIPTION
Update status to `Replaced` by HIP-24 as per https://github.com/hashgraph/hedera-improvement-proposal/discussions/59

Signed-off-by: Serg Metelin <sergey.metelin@hedera.com>