### PR TITLE
Update topicMessage chunkInfo transactionID format in HIP 171

### DIFF
--- a/HIP/hip-171.md
+++ b/HIP/hip-171.md
@@ -38,12 +38,17 @@ A `payer_account_id` field should be added to the JSON response of `/api/v1/topi
 
 We already have a `topic_message.payer_account_id` in the table but it is only populated if `chunkInfo` is present in the protobuf. Services validates that if `chunkInfo` is populated that the payer of the transaction must match `chunkInfo.payerAccountId`. So really we can just always populate it with the `transaction.payer_account_id` so it's present for both chunked and non-chunked messages. Then we can return it on the REST API without incurring the cost of a join against the transaction table. This will require a database migration to backfill this data for entries that are null.
 
-So the full topic message REST API response should become:
+So the full topic message REST API response (with consideration for the expanding transactionID object) should become:
 
 ```
 {
   "chunk_info": {
-    "initial_transaction_id": "0.0.1000-1234567890-000000006",
+    "initial_transaction_id": {
+      "account_id": "0.0.1000",
+      "nonce": 1,
+      "scheduled": true,
+      "transaction_valid_start": "1234567890.000000006"
+    },
     "number": 2,
     "total": 5
   },
@@ -75,7 +80,25 @@ TBD...
 
 ## Rejected Ideas
 
-N/A
+A previous idea expressed the transactionId in its string form as shown below.
+However, after consideration this option limits the information conveyed since the transactionId proto may expand with the change of the string e.g. addition of nonce, schedule
+
+```
+{
+  "chunk_info": {
+    "initial_transaction_id": "0.0.1000-1234567890-000000006",
+    "number": 2,
+    "total": 5
+  },
+  "consensus_timestamp": "1234567890.000000001",
+  "topic_id": "0.0.7",
+  "message": "bWVzc2FnZQ==",
+  "payer_account_id": "0.0.1000",
+  "running_hash": "cnVubmluZ19oYXNo",
+  "running_hash_version": 2,
+  "sequence_number": 1
+}
+```
 
 ## Open Issues
 


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Description**:
In v0.49 the mirror node implemented the design suggested by HIP 171.
During implementation after further consideration a more scalable format for the transactionId was agreed on.

- Update topicMessage chunkInfo transactionID format to use expanded JSON instead of string

**Related issue(s)**:

Fixes #

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
