### PR TITLE
Changes to Allowance protobuf messages

### DIFF
--- a/HIP/hip-336.md
+++ b/HIP/hip-336.md
@@ -51,23 +51,26 @@ The repeated fields `crypto_allowances`, `nft_allowances ` and `token_allowances
 ```protobuf
 // new message
 message CryptoAllowance {
-	AccountID spender = 1;
-	int64 amount = 2;
+	AccountID owner = 1;
+	AccountID spender = 2;
+	int64 amount = 3;
 }
 
 // new message
 message TokenAllowance {
 	TokenID tokenId = 1;
-	AccountID spender = 2;
-	int64 amount = 3;
+	AccountID owner = 2;
+	AccountID spender = 3;
+	int64 amount = 4;
 }
 	
 // new message
 message NftAllowance {
 	TokenID tokenId = 1;
-	AccountID spender = 2;
-	repeated int64 serialNumbers = 3;
-	google.protobuf.BoolValue approvedForAll = 4;
+	AccountID owner = 2;
+	AccountID spender = 3;
+	repeated int64 serialNumbers = 4;
+	google.protobuf.BoolValue approvedForAll = 5;
 }
 
 // existing protobuf
@@ -124,21 +127,24 @@ A new Hedera API will be added under the Crypto Service called `CryptoApproveAll
 
 ```protobuf
 message CryptoAllowance {
-	AccountID spender = 1;
-	int64 amount = 2;
-}
-
-message TokenAllowance {
-	TokenID tokenId = 1;
+	AccountID owner = 1;
 	AccountID spender = 2;
 	int64 amount = 3;
 }
 
+message TokenAllowance {
+	TokenID tokenId = 1;
+	AccountID owner = 2;
+	AccountID spender = 3;
+	int64 amount = 4;
+}
+
 message NftAllowance {
 	TokenID tokenId = 1;
-	AccountID spender = 2;
-	repeated int64 serialNumbers = 3;
-	google.protobuf.BoolValue approvedForAll = 4;
+	AccountID owner = 2;
+	AccountID spender = 3;
+	repeated int64 serialNumbers = 4;
+	google.protobuf.BoolValue approvedForAll = 5;
 }
 	
 message CryptoApproveAllowanceTransactionBody {
@@ -328,7 +334,7 @@ The transfer transaction will fail under the following circumstances:
 - The spender does not have an allowance established with the owner for the specified token.
 - The `amount` to transfer exceeds the spender's available allowance.
 - An NFT serial number is being transferred and the owner does not have possession of it.
-- Either the owner, spender or recipient accounts are frozen for the specified token.
+- Either the owner or recipient accounts are frozen for the specified token.
 - The specified `token` is paused.
 
 ### Change TransactionRecord to Contain Current Allowance Balance

--- a/HIP/hip-336.md
+++ b/HIP/hip-336.md
@@ -9,7 +9,7 @@ last-call-date-time: 2021-02-14T07:00:00Z
 status: Last Call
 created: 2022-01-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/337
-updated: 2022-01-27
+updated: 2022-02-01
 ---
 
 ## Abstract
@@ -150,7 +150,7 @@ message CryptoApproveAllowanceTransactionBody {
 
 This function contains a list of hbar and/or token approval messages. The `CryptoAllowance` and `TokenAllowance` messages will set an allowance of `amount` fungible tokens or hbar that can be transferred from the owner's account to another account by the `spender` account. The `NftAllowance` message sets an allowance for specific NFT serial numbers within the owner's account. Each of the hbar/token approvals in the list do not need to refer to the same spender. The owner can establish different allowances for various spenders in a single transaction.
 
-The total number of approvals contained within the transaction body cannot exceed 20. This number includes all hbar, fungible and non-fungible token approvals. Note that a single `NftAllowance` message counts as one approval regardless of the number of serial numbers specified within.
+The total number of approvals contained within the transaction body cannot exceed 20. This number includes all hbar, fungible and non-fungible token approvals. Note that each NFT serial number counts as a single approval, hence a transaction granting 20 serial numbers to a spender will use all of the approvals permitted for the transaction.
 
 The `amount` must be specified in terms of the `decimals` value for the token. If `amount` is 0 the transaction will remove the `spender`'s allowance from the owner's account, thereby freeing an allowance for future use.
 
@@ -166,9 +166,9 @@ It is not an error if either the spender or owner's accounts are frozen or KYC-r
 
 It is not an error if the token is paused and an allowance approval is submitted.
 
-The transaction must be signed by the owner's account and transaction fees will be paid by the payer account (which may or may not be the owner).
+The transaction must be signed by the owner's account and transaction fees will be paid by the owner only.
 
-Each account is limited to 100 allowances. This limit spans hbar, fungible and non-fungible token allowances.
+Each account is limited to 100 allowances. This limit spans hbar, fungible and non-fungible token allowances. Each NFT serial number will count as a single allowance when computing the total allowances an account currently has.
 
 The number of allowances set on an account will increase the auto renewal fee for the account. Conversely, removing allowances will decrease the auto renewal fee for the account.
 
@@ -239,7 +239,7 @@ It is not an error if either the spender or owner's accounts are frozen or KYC-r
 
 It is not an error if the token is paused and an allowance adjustment is submitted.
 
-The transaction must be signed by the owner's account and transaction fees will be paid by the payer account (which may or may not be the owner).
+The transaction must be signed by the owner's account and transaction fees will be paid by the owner only.
 
 The allowance adjustment transaction will fail under the following circumstances:
 
@@ -257,42 +257,52 @@ The allowance adjustment transaction will fail under the following circumstances
 
 ### Change CryptoTransfer to Support Approved Allowances
 
-The existing CryptoTransfer API will be used to support the transfer of tokens by a `spender` under their approved allowance. The existing protobuf message for `CryptoTransfer` will be reused with no changes; however the internal implementation of the API will change to support the additional approval semantics.
+The existing CryptoTransfer API will be used to support the transfer of tokens by a `spender` under their approved allowance. The existing protobuf message for `CryptoTransfer` will be reused with one minor change to the `AccountAmount` and `NftTransfer` messages - the addition of an `is_approval` field to indicate whether the transfer involves an approved transfer or not.
 
 ```protobuf
 // existing protobuf
 message CryptoTransferTransactionBody {
-    TransferList transfers = 1;
-    repeated TokenTransferList tokenTransfers = 2;
+	TransferList transfers = 1;
+	repeated TokenTransferList tokenTransfers = 2;
 }
 
 // existing protobuf
 message TransferList {
-    repeated AccountAmount accountAmounts = 1;
+	repeated AccountAmount accountAmounts = 1;
 }
 
-// existing protobuf
+// changed protobuf
 message AccountAmount {
-    AccountID accountID = 1;
-    sint64 amount = 2;
+	// existing fields
+	AccountID accountID = 1;
+	sint64 amount = 2;
+	
+	// new field
+	bool is_approval = 3;
 }
 
 // existing protobuf
 message TokenTransferList {
-    TokenID token = 1;
-    repeated AccountAmount transfers = 2;
-    repeated NftTransfer nftTransfers = 3;
+	TokenID token = 1;
+	repeated AccountAmount transfers = 2;
+	repeated NftTransfer nftTransfers = 3;
 }
 
-// existing protobuf
+// changed protobuf
 message NftTransfer {
-    AccountID senderAccountID = 1;
-    AccountID receiverAccountID = 2;
-    int64 serialNumber = 3;
+	// existing fields
+	AccountID senderAccountID = 1;
+   AccountID receiverAccountID = 2;
+   int64 serialNumber = 3;
+   
+   // new field
+   bool is_approval = 4;
 }
 ```
 
 The transaction can contain a list of regular transfers and approved transfers, each potentially referencing a different token and/or owner.
+
+The `is_approval` field must be set to `true` for transfers that will involve an approved allowance otherwise a regular transfer will be assumed. For hbar and fungible transfers the `is_approval` field must be set on the debiting `AccountAmount` while for NFTs the `is_approval` field is set on the transfer message itself. Multiple owner accounts can be involved in a single transfer by setting `is_approval` to `true` for each of the owner `AccountAmount` messages.
 
 The spender (acting here as the caller) must sign the transaction. The owner of the token (the party that approved the spender's allowance) is not required to sign the transaction.
 


### PR DESCRIPTION
**Description**:
Minor edits to sync HIP with protobuf changes required for implementation.
- Added is_approval to AccountAmount and NftTransfer messages. Needed to identify owner of allowance.
- Added owner to CryptoAllowance, TokenAllowance and NftAllowance. Future-proofing for mirror node.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
