### PR TITLE
Update CryptoGetInfo definition with latest protobufs

### DIFF
--- a/HIP/hip-336.md
+++ b/HIP/hip-336.md
@@ -9,7 +9,7 @@ last-call-date-time: 2021-02-14T07:00:00Z
 status: Approved
 created: 2022-01-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/337
-updated: 2022-02-01
+updated: 2022-02-22
 ---
 
 ## Abstract
@@ -42,35 +42,67 @@ The following terms will be used repeatedly throughout this section:
 
 - owner: the account that owns the tokens.
 - spender: the delegate account, the account being granted the power to spend the owner’s tokens.
-- recipient: the receiver of tokens when the spender issues a `CryptoTransfer ` operation.
+- recipient: the receiver of tokens when the spender issues a `CryptoTransfer` operation.
 
 ### Add Allowance Balances to CryptoGetInfoResponse
 
-The repeated fields `crypto_allowances`, `nft_allowances ` and `token_allowances` will be added to the `CryptoGetInfoResponse` message. The `crypto_allowances`, `nft_allowances` and `token_allowances` fields will contain hbar, non-fungible token and fungible token allowances respectively.
+The repeated fields `granted_crypto_allowances`, `granted_nft_allowances ` and `granted_token_allowances` will be added to the `CryptoGetInfoResponse` message. The `granted_crypto_allowances`, `granted_nft_allowances` and `granted_token_allowances` fields will contain hbar, non-fungible token and fungible token allowances respectively.
 
 ```protobuf
 // new message
-message CryptoAllowance {
-	AccountID owner = 1;
-	AccountID spender = 2;
-	int64 amount = 3;
+message GrantedCryptoAllowance {
+    /**
+     * The account ID of the spender of the hbar allowance.
+     */
+    AccountID spender = 1;
+
+    /**
+     * The amount of the spender's allowance in tinybars.
+     */
+    int64 amount = 2;
 }
 
 // new message
-message TokenAllowance {
-	TokenID tokenId = 1;
-	AccountID owner = 2;
-	AccountID spender = 3;
-	int64 amount = 4;
+message GrantedTokenAllowance {
+    /**
+     * The token that the allowance pertains to.
+     */
+    TokenID token_id = 1;
+
+    /**
+     * The account ID of the token allowance spender.
+     */
+    AccountID spender = 2;
+
+    /**
+     * The amount of the spender's token allowance.
+     */
+    int64 amount = 3;
 }
 	
 // new message
-message NftAllowance {
-	TokenID tokenId = 1;
-	AccountID owner = 2;
-	AccountID spender = 3;
-	repeated int64 serialNumbers = 4;
-	google.protobuf.BoolValue approvedForAll = 5;
+message GrantedNftAllowance {
+    /**
+     * The token that the allowance pertains to.
+     */
+    TokenID token_id = 1;
+
+    /**
+     * The account ID of the token allowance spender.
+     */
+    AccountID spender = 2;
+
+    /**
+     * The list of serial numbers that the spender is permitted to transfer.
+     */
+    repeated int64 serial_numbers = 3;
+
+    /**
+     * If true, the spender has access to all of the account owner's NFT instances (currently
+     * owned and any in the future). If this field is set to true the serialNumbers field
+     * should be empty.
+     */
+    bool approved_for_all = 4;
 }
 
 // existing protobuf
@@ -100,9 +132,9 @@ message CryptoGetInfoResponse {
 		bytes ledger_id = 20;
 
 		// new fields
-		repeated CryptoAllowance crypto_allowances = 21;
-		repeated NftAllowance nft_allowances = 22;
-		repeated TokenAllowance token_allowances = 23;
+		repeated GrantedCryptoAllowance granted_crypto_allowances = 21;
+		repeated GrantedNftAllowance granted_nft_allowances = 22;
+		repeated GrantedTokenAllowance granted_token_allowances = 23;
 	}
 
 	// existing fields
@@ -111,9 +143,9 @@ message CryptoGetInfoResponse {
 }
 ```
 
-The `TokenAllowance` message will contain the allowance information for a single fungible token tranferable by the `spender`.
+The `GrantedTokenAllowance` message will contain the allowance information for a single fungible token tranferable by the `spender`.
 
-The `NftAllowance` message will contain the allowance information for a non-fungible token. A `spender` will only have access to the specific NFT serial numbers that the owner has granted them (exception being `approvedForAll` case, explained below).
+The `GrantedNftAllowance` message will contain the allowance information for a non-fungible token. A `spender` will only have access to the specific NFT serial numbers that the owner has granted them (exception being `approvedForAll` case, explained below).
 
 For non-fungible tokens the `approvedForAll` field may be set to `true` if the spender has been granted access to all instances of the NFT owned by the owner. If an NFT has `approvedForAll` set to `true` then `serialNumbers` will not contain any values.
 


### PR DESCRIPTION
Signed-off-by: Albert Tam <albert.tam@hedera.com>

**Description**:
Changed protobuf definitions in HIP to match recent changes made for CryptoGetInfo. The XAllowance messages have been cloned into GrantedXAllowances (for crypto, token and nft). The GrantedXAllowance messages do not have the owner field present as these could potentially cause confusion. The XAllowance messages are still use for approval + adjustment transactions.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
