### PR TITLE
HIP-218 update list of supported ERC20 and ERC721 functions

### DIFF
--- a/HIP/hip-218.md
+++ b/HIP/hip-218.md
@@ -68,7 +68,7 @@ Each HTS account will expose a standard redirection EVM bytestream. This
 bytestream will be available to `EXTCODEHASH`, `EXTCODESIZE` and `EXTCODECOPY`
 operations as though the smart contract were deployed itself. The EVM will
 execute the bytecode, which will wrap the call data with the address of the HTS
-Token, to a call to teh HTS precompile. The HTS precompile will then either
+Token, to a call to the HTS precompile. The HTS precompile will then either
 execute or reject the call based on `IERC20` mappings described in the next
 section.
 
@@ -108,19 +108,12 @@ be emitted as appropriate.
 - `function balanceOf(address account) external view returns (uint256)`
 - `function transfer(address recipient, uint256 amount) external returns (bool)`
 
-The following ERC-20 operations will not be directly supported and will return a
-failure if called.
+The following ERC-20 operations will not be supported with this HIP implementation 
+and will return a failure if called. Support for these function will be added with 
+another improvement proposal.
 
 - `function allowance(address owner, address spender) external view returns (uint256);`
 - `function approve(address spender, uint256 amount) external returns (bool);`
-
-The following ERC-20 operations will have modified support. If the transaction
-is authorized by both the sender and the receiver it will be executed.
-Ordinarily an `approve` call is needed to set this up or the call needs to come
-from the `sender` account. But since Hedera allows multiple signatures on a
-transaction and allows multiple accounts to be authorized by the same key more
-complex authorizations can be permitted.
-
 - `function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);`
 
 #### Supported ERC-721 operations
@@ -133,28 +126,35 @@ be emitted as appropriate.
 - From interface ERC721
   - `function balanceOf(address _owner) external view returns (uint256)`
   - `function ownerOf(uint256 _tokenId) external view returns (address)`
-  - `function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes data) external payable`
-  - `function safeTransferFrom(address _from, address _to, uint256 _tokenId) external payable`
-  - `function transferFrom(address _from, address _to, uint256 _tokenId) external payable`
 - From interface ERC721Metadata
   - `function name() external view returns (string _name)`
   - `function symbol() external view returns (string _symbol)`
   - `function tokenURI(uint256 _tokenId) external view returns (string)`
 - From interface ERC721Enumerable
   - `function totalSupply() external view returns (uint256)`
-  - `function tokenByIndex(uint256 _index) external view returns (uint256)`
-  - `function tokenOfOwnerByIndex(address _owner, uint256 _index) external view returns (uint256)`
 
 The following ERC-721 operations will not be directly supported and will return
 a failure if called.
+
+- From interface ERC721
+  - `function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes data) external payable`
+  - `function safeTransferFrom(address _from, address _to, uint256 _tokenId) external payable`
+- All semantics of interface ERC721TokenReceiver.
+  - Existing Hedera token association rules will take the place of such checks.
+- From interface ERC721Enumerable
+  - `function tokenByIndex(uint256 _index) external view returns (uint256)`
+  - `function tokenOfOwnerByIndex(address _owner, uint256 _index) external view returns (uint256)`
+
+The following ERC-20 operations will not be supported with this HIP implementation 
+and will return a failure if called. Support for these function will be added with 
+another improvement proposal.
 
 - From interface ERC721
   - `function approve(address _approved, uint256 _tokenId) external payable`
   - `function setApprovalForAll(address _operator, bool _approved) external`
   - `function getApproved(uint256 _tokenId) external view returns (address)`
   - `function isApprovedForAll(address _owner, address _operator) external view returns (bool)`
-- All semantics of interface ERC721TokenReceiver.
-  - Existing Hedera token association rules will take the place of such checks.
+  - `function transferFrom(address _from, address _to, uint256 _tokenId) external payable`
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
**Description**:

Update HIP-218 after decision was made to exclude `transferFrom` support as it was implemented for 0.24 and implement it at a later stage with support for `approve/allowance` functions as well.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
