### PR TITLE
HIP-376 Support Approve/Allowance/transferFrom standard calls from ERC20 and ERC721

### DIFF
--- a/HIP/hip-0000.md
+++ b/HIP/hip-0000.md
@@ -1,0 +1,155 @@
+---
+hip: 
+title: Support for Approve/Allowance and ERC20/ERC721 transferFrom in HTS precompile
+author: Stoyan Panayotov <stoyan.panayotov@limechain.tech>
+type: Standards Track
+category: Service
+needs-council-approval: Yes
+status: Review
+created: 2022-03-02
+discussions-to: 
+updated: 
+requires: 206, 218
+---
+
+## Abstract
+
+Extend the functionality from HIP-218 for ERC20 and ERC721 funtions working on
+HTS tokens with support for approve/allowance and transferFrom functions.
+
+## Motivation
+
+The goal of this HIP is to enable users of the HSCS to interact with Hedera
+native tokens in a manner that is similar to how they would in other EVM based
+systems. 
+
+## Rationale
+
+The standard model of ERC-20 and ERC-721 interactions involves directly calling
+the account address. Solidity, however, does a code size check before calling a
+smart contract and reverts if it finds no code. To address this a simple proxy
+redirect is proposed to be added to each token contract accessed that will
+redirect the call (including information about what address was called). HSCS
+will report all token address have this precompile, permitting solidity to
+interact with the token addresses as though it was an account with code.
+
+## User stories
+
+As a hedera smart contract services user, I want to be able to access my HTS
+fungible tokens like an Ethereum ERC-20 token.
+
+As a hedera smart contract services user, I want to be able to access my HTS
+non-fungible tokens like an Ethereum ERC-721 token.
+
+As a hedera smart contract services user, I want to be able to access metadata
+provided by the getTokenInfo in a smart contract.
+
+## Specification
+
+### EVM Precompile
+
+The HTS precompile described in HIP-206, at address `0x167`,will be extended to
+recognize one more function call: `redirectForToken(address,bytes)`. 
+
+### ERC-20 calls directly to Token Accounts
+
+To enable HTS tokens to be more broadly used in DeFi applications the
+interactions with HSCS and Token accounts will be enhanced to allow HTS accounts
+to receive smart contract calls that will be immediately delegated to the HTS
+precompile for evaluation.
+
+#### Redirect contract
+
+Each HTS account will expose a standard redirection EVM bytestream. This
+bytestream will be available to `EXTCODEHASH`, `EXTCODESIZE` and `EXTCODECOPY`
+operations as though the smart contract were deployed itself. The EVM will
+execute the bytecode, which will wrap the call data with the address of the HTS
+Token, to a call to teh HTS precompile. The HTS precompile will then either
+execute or reject the call based on `IERC20` mappings described in the next
+section.
+
+(The following pseudocode will be replaced with real EVM opcodes prior to
+review)
+> ```
+>
+>// Put CALLER in memory
+>// Put the remaining CALLDATA into memory
+>// DELEGATECALL 0x127 with all remaining gas
+>// if the DELEGATECALL failed REVERT()
+>// RETURN the exact same results as the DELEGATECALL
+>
+>```
+
+#### Gas Schedule
+
+For function calls that cause HTS token transfers the appropriate gas charges
+will be applied. Calls that emit events will be charged the event fees too.
+
+For other functions that return data the cost will be 10 gas per 32 bytes
+returned or fraction fo 32 bytes returned. For functions that return integers or
+an address this will be a flat 10 gas. For string values (name, symbol, etc.)
+this will be a variable fee.
+
+#### Supported ERC-20 operations
+
+Tokens of type FUNGIBLE_COMMON will support standard ERC-20 calls.
+
+The following ERC-20 operations will be supported. Standard ERC-20 Events will
+be emitted as appropriate.
+
+- `function allowance(address owner, address spender) external view returns (uint256);`
+- `function approve(address spender, uint256 amount) external returns (bool);`
+- `function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);`
+
+#### Supported ERC-721 operations
+
+Tokens of type NON_FUNGIBLE_UNIQUE will support standard ERC-721 calls.
+
+The following ERC-721 operations will be supported. Standard ERC-721 Events will
+be emitted as appropriate.
+
+- From interface ERC721
+  - `function transferFrom(address _from, address _to, uint256 _tokenId) external payable`
+  - `function approve(address _approved, uint256 _tokenId) external payable`
+  - `function setApprovalForAll(address _operator, bool _approved) external`
+  - `function getApproved(uint256 _tokenId) external view returns (address)`
+  - `function isApprovedForAll(address _owner, address _operator) external view returns (bool)`
+
+## Backwards Compatibility
+
+The existing functions in the HTS precompile will remain in place, all prior
+usages of the precompile will function as they did before.
+
+## Security Implications
+
+The same implications relating to contract keys and delegate calls outlined in
+HIP-206 also apply to the direct support of ERC-20 and ERC-721 contracts.
+
+## How to Teach This
+
+Tutorials and SDK examples should be written showing how solidity can access the
+token accounts directly as ERC-20 and ERC-721 contracts.
+
+HSCS documentation should be updated to explicitly enumerate the supported and
+non-supported contract functions.
+
+## Reference Implementation
+
+// TODO
+
+## Rejected Ideas
+
+
+## Open Issues
+
+None at this time.
+
+## References
+
+- [ERC-20: Token Standard](https://eips.ethereum.org/EIPS/eip-20)
+- [ERC-721: Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721)
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 --
+see [LICENSE](../LICENSE) or (https://www.apache.org/licenses/LICENSE-2.0)

--- a/HIP/hip-376.md
+++ b/HIP/hip-376.md
@@ -1,5 +1,5 @@
 ---
-hip: 
+hip: 376
 title: Support for Approve/Allowance and ERC20/ERC721 transferFrom in HTS precompile
 author: Stoyan Panayotov <stoyan.panayotov@limechain.tech>
 type: Standards Track

--- a/HIP/hip-376.md
+++ b/HIP/hip-376.md
@@ -24,11 +24,11 @@ The goal is to expose [HIP-336](https://hips.hedera.com/hip/hip-336): Approval a
 
 ### Fungible token related stories
 
-As a hedera smart contract services user, I want to enable another user the ability to spend `x` fungible tokens from my account so that they can trade on my behalf without requiring that I expose my private key to them.
+As a hedera smart contract services user, I want to enable another user or contract the ability to spend `x` fungible tokens from my account so that they can trade on my behalf without requiring that I expose my private key to them.
 
 As a hedera smart contract services user, I want to query tokens for the current token allowances that have been granted to a user (spender) for a specific owner account.
 
-As a hedera smart contract services user, I want to modify or remove an allowance I have granted to another user so that I can manage that user's ability to spend my tokens over time.
+As a hedera smart contract services user, I want to modify or remove an allowance I have granted to another user or contract so that I can manage that user/contract's ability to spend my tokens over time.
 
 As a hedera smart contract services user that has been granted an allowance, I want to be able to  transfer tokens owned by the owner account as if they were my tokens so that I can issue transfers on their behalf without them having to expose their private key.
 
@@ -40,8 +40,7 @@ As a hedera smart contract services user, I want to enable or disable another us
 
 As a hedera smart contract services user, I want to modify or remove an allowance I have granted to another user so that I can manage that user's ability to spend my tokens over time.
 
-// TODO: can we allow multiple accounts for the same NFT in Hedera? What should happen then when we call getApproved?
-As a hedera smart contract services user, I want t
+As a hedera smart contract services user, I want to query a token for the information whether an account has approve for all nfts permission.
 
 As a hedera smart contract services user that has been granted an allowance, I want to be able to  transfer tokens owned by the owner account as if they were my tokens so that I can issue transfers on their behalf without them having to expose their private key.
 
@@ -53,7 +52,7 @@ Extend the functionality from [HIP-218](https://hips.hedera.com/hip/hip-218): Sm
 
 #### Supported ERC-20 operations
 
-Tokens of type `FUNGIBLE_COMMON` will support standard `ERC-20` calls.
+Tokens of type `FUNGIBLE_COMMON` support standard `ERC-20` calls.
 
 The following `ERC-20` operations will be supported. Standard `ERC-20 Events` will be emitted as appropriate.
 
@@ -72,6 +71,41 @@ The following `ERC-721` operations will be supported. Standard `ERC-721 Events` 
   - `function getApproved(uint256 _tokenId) external view returns (address)`
   - `function isApprovedForAll(address _owner, address _operator) external view returns (bool)`
   - `function transferFrom(address _from, address _to, uint256 _tokenId) external payable`
+
+#### ERC20 and ERC721 mapping to the HAPI interface
+
+There are several differences in the way `ERC20` and `ERC721` functions are designed to behave and the way HAPI transactions for `approve`, `allowance` and `transferFrom` are implemented in Hedera. This section describes the integration between the function specifications and the actual Hedera behaviour.
+
+##### ERC20 approve and HAPI Adjust allowance
+
+ERC20 `approve` function works by overriding the previous value (if any was set) for the 'spender' address specified.
+HAPI `CryptoAdjustAllowance` transactions work by applying the difference specified by the `amount` field in the transaction body to the existing allowance (or 0 if there is no existing allowance approved for that account).
+Calling ERC20 `approve` with amount `200` will be implemented in the following way in the precompile:
+ - query the current configured allowance for the `owner`, `spender` and `tokenId`
+ - calculate the adjustment that needs to be made to have the final allowance equal to the amount received as argument to the ERC20 `approve`
+ - create a `CryptoAdjustAllowance` tx with the calculated adjustment
+
+##### ERC721 approve and multiple approved accounts for NFT in Hedera
+
+ERC721 is designed in such a way that an NFT can have either 0 or 1 approvals e.g. if Alice owns NFT 'X' and Alice calls the approve function two times, once with Bob's account and once with Carol's account, the second call to approve will override Bob's allowance and only Carol will have approved allowance for that NFT. In Hedera the behaviour is different and both Bob and Carol would have approved allowances after the second call to approve.
+To make sure there is no unexpected result for smart contract developers working with HTS tokens, ERC721 `approve` and `getApproved` will behave in the following way with HTS tokens:
+When `approve` is called:
+ - first we'll check if the address from the function arguments is the zero address
+ - if yes, then we'll iterate through the account's `GrantedNFTAllowances` and revoke (adjust with -) any existing approvals for the NFT serial number
+ - in no, then we'll check if the owner account has exactly 0 existing approvals for that NFT serial number
+ - if yes, we'll add the approval
+ - if no, then we revert and require HAPI manipulation of approvals
+
+When `getApproved` is called:
+ - we'll check whether the owner account has exactly zero or one approvals granted for that NFT serial number
+ - if yes, we'll return either zero (specifying there are no approvals) or the address of the approved account
+ - if no, then we revert and require HAPI manipulation of approvals
+
+##### HAPI payer, allowance and signatures for transferFrom
+
+HAPI cryptoTransfer functions using allowance work with the transaction payer - this is the account that should have allowance to spend the tokens. 
+ERC transferFrom functions work with msg.sender and that is the account that will be verified in the context of a precompile. 
+Additionaly, in HAPI TX context, the spender account must have signed the transaction for the transfer to be valid. We have already introduced an exception for signatures verification in the case when the `owner` and the `initiator` of a transfer through the precompile are the same account. This exception will now be extended to also include the `spender` of an allowance.
 
 #### Gas Schedule
 

--- a/HIP/hip-376.md
+++ b/HIP/hip-376.md
@@ -1,6 +1,6 @@
 ---
 hip: 376
-title:  Support Approve/Allowance/transferFrom standard calls from ERC20 and ERC721
+title: Support Approve/Allowance/transferFrom standard calls from ERC20 and ERC721
 author: Stoyan Panayotov <stoyan.panayotov@limechain.tech>
 type: Standards Track
 category: Service

--- a/HIP/hip-376.md
+++ b/HIP/hip-376.md
@@ -92,7 +92,7 @@ To make sure there is no unexpected result for smart contract developers working
 When `approve` is called:
  - first we'll check if the address from the function arguments is the zero address
  - if yes, then we'll iterate through the account's `GrantedNFTAllowances` and revoke (adjust with -) any existing approvals for the NFT serial number
- - in no, then we'll check if the owner account has exactly 0 existing approvals for that NFT serial number
+ - if no, then we'll check if the owner account has exactly 0 existing approvals for that NFT serial number
  - if yes, we'll add the approval
  - if no, then we revert and require HAPI manipulation of approvals
 

--- a/HIP/hip-376.md
+++ b/HIP/hip-376.md
@@ -5,10 +5,10 @@ author: Stoyan Panayotov <stoyan.panayotov@limechain.tech>
 type: Standards Track
 category: Service
 needs-council-approval: Yes
-status: Review
+status: Last Call
+last-call-date-time: 2022-04-06T07:00:00Z
 created: 2022-03-02
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/378
-updated: 
 requires: 206, 218, 336
 ---
 

--- a/HIP/hip-376.md
+++ b/HIP/hip-376.md
@@ -14,59 +14,48 @@ requires: 206, 218, 336
 
 ## Abstract
 
-Extend the functionality from [HIP-218](https://hips.hedera.com/hip/hip-218): Smart Contract interactions with Hedera Token Accounts with support for `approve`, `allowance` and `transferFrom` functions.
+Describe the added support for industry standart `ERC20` and `ERC721` functions related to token approvals and allowances in Hedera's Smart Contract Service.
 
 ## Motivation
 
-The goal is to expose [HIP-336](https://hips.hedera.com/hip/hip-336): Approval and Allowance API for Tokens functionality in industry standard ERC-20 and ERC-721 calls for smart contract developers on Hedera.
-
-## Rationale
-
-// TODO
+The goal is to expose [HIP-336](https://hips.hedera.com/hip/hip-336): Approval and Allowance API for Tokens functionality in industry standard `ERC-20` and `ERC-721` calls for smart contract developers on Hedera.
 
 ## User stories
-// TODO check this, copied from app/all hip
-As a smart contract developer, I want to enable another user the ability to spend `x` tokens (hbar and fungible tokens) from my account so that they can trade on my behalf without requiring that I expose my private key to them.
 
-As a user, I want to enable another user the ability to spend specific non-fungible tokens from my account so that they can trade on my behalf without requiring that I expose my private key to them.
+### Fungible token related stories
 
-As a user, I want to enable another user the ability to spend all instances of a particular non-fungible token that I currently or may in the future hold in my account so that they can trade on my behalf without requiring that I expose my private key to them.
+As a hedera smart contract services user, I want to enable another user the ability to spend `x` fungible tokens from my account so that they can trade on my behalf without requiring that I expose my private key to them.
 
-As a user, I want to modify or remove an allowance I have granted to another user so that I can manage that user's ability to spend my tokens over time.
+As a hedera smart contract services user, I want to query tokens for the current token allowances that have been granted to a user (spender) for a specific owner account.
 
-As a user that has been granted an allowance, I want to be able to  transfer tokens owned by the owner account as if they were my tokens so that I can issue transfers on their behalf without them having to expose their private key.
+As a hedera smart contract services user, I want to modify or remove an allowance I have granted to another user so that I can manage that user's ability to spend my tokens over time.
 
-As a user, I want to query my account for the current token allowances that I have granted to other users so that I can monitor the activity of my delegates.
+As a hedera smart contract services user that has been granted an allowance, I want to be able to  transfer tokens owned by the owner account as if they were my tokens so that I can issue transfers on their behalf without them having to expose their private key.
+
+### Non-fungible token related stories
+
+As a hedera smart contract services user, I want to enable another user the ability to spend specific non-fungible tokens from my account so that they can trade on my behalf without requiring that I expose my private key to them.
+
+As a hedera smart contract services user, I want to enable or disable another user the ability to spend all instances of a particular non-fungible token that I currently or may in the future hold in my account so that they can trade on my behalf without requiring that I expose my private key to them.
+
+As a hedera smart contract services user, I want to modify or remove an allowance I have granted to another user so that I can manage that user's ability to spend my tokens over time.
+
+// TODO: can we allow multiple accounts for the same NFT in Hedera? What should happen then when we call getApproved?
+As a hedera smart contract services user, I want t
+
+As a hedera smart contract services user that has been granted an allowance, I want to be able to  transfer tokens owned by the owner account as if they were my tokens so that I can issue transfers on their behalf without them having to expose their private key.
 
 ## Specification
 
 ### EVM Precompile
 
-[!reference to 218]
-
-#### Gas Schedule
-
-For function calls that cause HTS token transfers the appropriate gas charges
-will be applied. Calls that emit events will be charged the event fees too.
-
-For other functions that return data the cost will be 10 gas per 32 bytes
-returned or fraction fo 32 bytes returned. For functions that return integers or
-an address this will be a flat 10 gas. For string values (name, symbol, etc.)
-this will be a variable fee.
-
-[!Now that we know what we did for HIP-206 and HIP-218 gas-wise I think we should add a table for each "function group" and the gas price we expect, including the assumptions used to calculate them.
-
-We take the canonical max calls per second, and divide that into the 15MM gas per second, and add a 20% premium. The trick is figuring out which max TPX measure to use.
-
-We also want to think of the event emissions cost. My thought is we include those in the precompile gas cost.]
-
+Extend the functionality from [HIP-218](https://hips.hedera.com/hip/hip-218): Smart Contract interactions with Hedera Token Accounts with support for `approve`, `allowance` and `transferFrom` functions.
 
 #### Supported ERC-20 operations
 
-Tokens of type FUNGIBLE_COMMON will support standard ERC-20 calls.
+Tokens of type `FUNGIBLE_COMMON` will support standard `ERC-20` calls.
 
-The following ERC-20 operations will be supported. Standard ERC-20 Events will
-be emitted as appropriate.
+The following `ERC-20` operations will be supported. Standard `ERC-20 Events` will be emitted as appropriate.
 
 - `function allowance(address owner, address spender) external view returns (uint256);`
 - `function approve(address spender, uint256 amount) external returns (bool);`
@@ -74,35 +63,41 @@ be emitted as appropriate.
 
 #### Supported ERC-721 operations
 
-Tokens of type NON_FUNGIBLE_UNIQUE will support standard ERC-721 calls.
+Tokens of type `NON_FUNGIBLE_UNIQUE` will support standard `ERC-721` calls.
 
-The following ERC-721 operations will be supported. Standard ERC-721 Events will
-be emitted as appropriate.
+The following `ERC-721` operations will be supported. Standard `ERC-721 Events` will be emitted as appropriate.
 
-- From interface ERC721
-  - `function transferFrom(address _from, address _to, uint256 _tokenId) external payable`
   - `function approve(address _approved, uint256 _tokenId) external payable`
   - `function setApprovalForAll(address _operator, bool _approved) external`
   - `function getApproved(uint256 _tokenId) external view returns (address)`
   - `function isApprovedForAll(address _owner, address _operator) external view returns (bool)`
+  - `function transferFrom(address _from, address _to, uint256 _tokenId) external payable`
+
+#### Gas Schedule
+
+For function calls that cause HTS token transfers the appropriate gas charges will be applied. Calls that emit events will be charged the event fees too.
+
+We take the canonical max calls per second, and divide that into the 15MM gas per second, and add a 20% premium. The trick is figuring out which max TPX measure to use.
+
+| Function         | Base Cost |  Incremental Cost |
+| -----------------| --------: | ----------------: |
+| Queries          |    xx Gas |             0 Gas |
+| Approves         |    xx Gas |             0 Gas |
+| Transfer         |    xx Gas |             0 Gas |
 
 ## Backwards Compatibility
 
-The existing functions in the HTS precompile will remain in place, all prior
-usages of the precompile will function as they did before.
+The existing functions in the HTS precompile will remain in place, all prior usages of the precompile will function as they did before.
 
 ## Security Implications
 
-The same implications relating to contract keys and delegate calls outlined in
-HIP-206 also apply to the direct support of ERC-20 and ERC-721 contracts.
+The same implications relating to contract keys and delegate calls outlined in HIP-206 also apply to the direct support of ERC-20 and ERC-721 contracts.
 
 ## How to Teach This
 
-Tutorials and SDK examples should be written showing how solidity can access the
-token accounts directly as ERC-20 and ERC-721 contracts.
+Tutorials and SDK examples should be written showing how solidity can access the token accounts directly as ERC-20 and ERC-721 contracts.
 
-HSCS documentation should be updated to explicitly enumerate the supported and
-non-supported contract functions.
+HSCS documentation should be updated to explicitly enumerate the supported and non-supported contract functions.
 
 ## Reference Implementation
 
@@ -124,5 +119,4 @@ None at this time.
 
 ## Copyright/license
 
-This document is licensed under the Apache License, Version 2.0 --
-see [LICENSE](../LICENSE) or (https://www.apache.org/licenses/LICENSE-2.0)
+This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](../LICENSE) or (https://www.apache.org/licenses/LICENSE-2.0)

--- a/HIP/hip-376.md
+++ b/HIP/hip-376.md
@@ -1,84 +1,48 @@
 ---
 hip: 376
-title: Support for Approve/Allowance and ERC20/ERC721 transferFrom in HTS precompile
+title:  Support Approve/Allowance/transferFrom standard calls from ERC20 and ERC721
 author: Stoyan Panayotov <stoyan.panayotov@limechain.tech>
 type: Standards Track
 category: Service
 needs-council-approval: Yes
 status: Review
 created: 2022-03-02
-discussions-to: 
+discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/378
 updated: 
-requires: 206, 218
+requires: 206, 218, 336
 ---
 
 ## Abstract
 
-Extend the functionality from HIP-218 for ERC20 and ERC721 funtions working on
-HTS tokens with support for approve/allowance and transferFrom functions.
+Extend the functionality from [HIP-218](https://hips.hedera.com/hip/hip-218): Smart Contract interactions with Hedera Token Accounts with support for `approve`, `allowance` and `transferFrom` functions.
 
 ## Motivation
 
-The goal of this HIP is to enable users of the HSCS to interact with Hedera
-native tokens in a manner that is similar to how they would in other EVM based
-systems. 
+The goal is to expose [HIP-336](https://hips.hedera.com/hip/hip-336): Approval and Allowance API for Tokens functionality in industry standard ERC-20 and ERC-721 calls for smart contract developers on Hedera.
 
 ## Rationale
 
-The standard model of ERC-20 and ERC-721 interactions involves directly calling
-the account address. Solidity, however, does a code size check before calling a
-smart contract and reverts if it finds no code. To address this a simple proxy
-redirect is proposed to be added to each token contract accessed that will
-redirect the call (including information about what address was called). HSCS
-will report all token address have this precompile, permitting solidity to
-interact with the token addresses as though it was an account with code.
+// TODO
 
 ## User stories
+// TODO check this, copied from app/all hip
+As a smart contract developer, I want to enable another user the ability to spend `x` tokens (hbar and fungible tokens) from my account so that they can trade on my behalf without requiring that I expose my private key to them.
 
-As a hedera smart contract services user, I want to be able to access my HTS
-fungible tokens like an Ethereum ERC-20 token.
+As a user, I want to enable another user the ability to spend specific non-fungible tokens from my account so that they can trade on my behalf without requiring that I expose my private key to them.
 
-As a hedera smart contract services user, I want to be able to access my HTS
-non-fungible tokens like an Ethereum ERC-721 token.
+As a user, I want to enable another user the ability to spend all instances of a particular non-fungible token that I currently or may in the future hold in my account so that they can trade on my behalf without requiring that I expose my private key to them.
 
-As a hedera smart contract services user, I want to be able to access metadata
-provided by the getTokenInfo in a smart contract.
+As a user, I want to modify or remove an allowance I have granted to another user so that I can manage that user's ability to spend my tokens over time.
+
+As a user that has been granted an allowance, I want to be able to  transfer tokens owned by the owner account as if they were my tokens so that I can issue transfers on their behalf without them having to expose their private key.
+
+As a user, I want to query my account for the current token allowances that I have granted to other users so that I can monitor the activity of my delegates.
 
 ## Specification
 
 ### EVM Precompile
 
-The HTS precompile described in HIP-206, at address `0x167`,will be extended to
-recognize one more function call: `redirectForToken(address,bytes)`. 
-
-### ERC-20 calls directly to Token Accounts
-
-To enable HTS tokens to be more broadly used in DeFi applications the
-interactions with HSCS and Token accounts will be enhanced to allow HTS accounts
-to receive smart contract calls that will be immediately delegated to the HTS
-precompile for evaluation.
-
-#### Redirect contract
-
-Each HTS account will expose a standard redirection EVM bytestream. This
-bytestream will be available to `EXTCODEHASH`, `EXTCODESIZE` and `EXTCODECOPY`
-operations as though the smart contract were deployed itself. The EVM will
-execute the bytecode, which will wrap the call data with the address of the HTS
-Token, to a call to teh HTS precompile. The HTS precompile will then either
-execute or reject the call based on `IERC20` mappings described in the next
-section.
-
-(The following pseudocode will be replaced with real EVM opcodes prior to
-review)
-> ```
->
->// Put CALLER in memory
->// Put the remaining CALLDATA into memory
->// DELEGATECALL 0x127 with all remaining gas
->// if the DELEGATECALL failed REVERT()
->// RETURN the exact same results as the DELEGATECALL
->
->```
+[!reference to 218]
 
 #### Gas Schedule
 
@@ -89,6 +53,13 @@ For other functions that return data the cost will be 10 gas per 32 bytes
 returned or fraction fo 32 bytes returned. For functions that return integers or
 an address this will be a flat 10 gas. For string values (name, symbol, etc.)
 this will be a variable fee.
+
+[!Now that we know what we did for HIP-206 and HIP-218 gas-wise I think we should add a table for each "function group" and the gas price we expect, including the assumptions used to calculate them.
+
+We take the canonical max calls per second, and divide that into the 15MM gas per second, and add a 20% premium. The trick is figuring out which max TPX measure to use.
+
+We also want to think of the event emissions cost. My thought is we include those in the precompile gas cost.]
+
 
 #### Supported ERC-20 operations
 
@@ -148,6 +119,8 @@ None at this time.
 
 - [ERC-20: Token Standard](https://eips.ethereum.org/EIPS/eip-20)
 - [ERC-721: Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721)
+- [HIP-218: Smart Contract interactions with Hedera Token Accounts](https://hips.hedera.com/hip/hip-218)
+- [HIP-336: Approval and Allowance API for Tokens](https://hips.hedera.com/hip/hip-336)
 
 ## Copyright/license
 


### PR DESCRIPTION
**Description**:
Extend the support for ERC20 and ERC721 functions to be called on HTS tokens with support for Approve/allowance and transferFrom

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
