### PR TITLE
Modified approve/adjust for ERC721 compatibility

### DIFF
--- a/HIP/hip-336.md
+++ b/HIP/hip-336.md
@@ -9,7 +9,7 @@ last-call-date-time: 2021-02-14T07:00:00Z
 status: Approved
 created: 2022-01-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/337
-updated: 2022-03-16
+updated: 2022-03-24
 ---
 
 ## Abstract
@@ -30,6 +30,8 @@ As a user, I want to enable another user the ability to spend all instances of a
 
 As a user, I want to modify or remove an allowance I have granted to another user so that I can manage that user's ability to spend my tokens over time.
 
+As a user, I want to remove all allowances I have granted without having to specify the spender account so that I can easily manage my approvals without issuing multiple queries first.
+
 As a user that has been granted an allowance, I want to be able to  transfer tokens owned by the owner account as if they were my tokens so that I can issue transfers on their behalf without them having to expose their private key.
 
 As a user, I want to query my account for the current token allowances that I have granted to other users so that I can monitor the activity of my delegates.
@@ -46,7 +48,7 @@ The following terms will be used repeatedly throughout this section:
 
 ### Add Allowance Balances to CryptoGetInfoResponse
 
-The repeated fields `granted_crypto_allowances`, `granted_nft_allowances ` and `granted_token_allowances` will be added to the `CryptoGetInfoResponse` message. The `granted_crypto_allowances`, `granted_nft_allowances` and `granted_token_allowances` fields will contain hbar, non-fungible token and fungible token allowances respectively.
+The repeated fields `granted_crypto_allowances`, `granted_nft_allowances` and `granted_token_allowances` will be added to the `CryptoGetInfoResponse` message. The `granted_crypto_allowances`, `granted_nft_allowances` and `granted_token_allowances` fields will contain hbar, non-fungible token and fungible token allowances respectively.
 
 ```protobuf
 // new message
@@ -88,21 +90,9 @@ message GrantedNftAllowance {
     TokenID token_id = 1;
 
     /**
-     * The account ID of the token allowance spender.
+     * The account ID of the spender that has been granted access to all NFTs of the owner.
      */
     AccountID spender = 2;
-
-    /**
-     * The list of serial numbers that the spender is permitted to transfer.
-     */
-    repeated int64 serial_numbers = 3;
-
-    /**
-     * If true, the spender has access to all of the account owner's NFT instances (currently
-     * owned and any in the future). If this field is set to true the serialNumbers field
-     * should be empty.
-     */
-    bool approved_for_all = 4;
 }
 
 // existing protobuf
@@ -145,13 +135,34 @@ message CryptoGetInfoResponse {
 
 The `GrantedTokenAllowance` message will contain the allowance information for a single fungible token tranferable by the `spender`.
 
-The `GrantedNftAllowance` message will contain the allowance information for a non-fungible token. A `spender` will only have access to the specific NFT serial numbers that the owner has granted them (exception being `approvedForAll` case, explained below).
-
-For non-fungible tokens the `approvedForAll` field may be set to `true` if the spender has been granted access to all instances of the NFT owned by the owner. If an NFT has `approvedForAll` set to `true` then `serialNumbers` will not contain any values.
+The `GrantedNftAllowance` message will contain the allowance information for a non-fungible token. The listed `spender` will be approved to spend all of the serial numbers owned by the owner for the specific NFT token. The list of serial numbers that have been approved to spenders will **not** be returned as this information is not tracked on the owner's account. This behavior is consistent with the ERC721 implementation and should not be a surprise to Ethereum developers.
 
 Only allowances with a non-zero value will be returned.
 
 The `spender`'s allowance will change as tokens are spent or additional allowances are approved by the token owner.
+
+### Add Spender ID to TokenNftInfo
+
+The current spender that has been approved access to an NFT serial number will be added to the `TokenNftInfo` message that is returned as part of the `TokenGetNftInfoResponse` and `TokenGetNftInfosResponse`.
+
+```protobuf
+// existing message
+message TokenNftInfo {
+	// existing fields
+	NftID nftID = 1;
+	AccountID accountID = 2;	// current owner
+	Timestamp creationTime = 3;
+	bytes metadata = 4;
+	bytes ledger_id = 5;
+ 
+	// new field
+	AccountID spender_id = 6;
+}
+```
+
+Only one spender can be assigned to an NFT serial number at a time.
+
+If the NFT serial number has not been approved to spend by an account, the `spender_id` field will not be included.
 
 ### Add CryptoApproveAllowance API
 
@@ -192,9 +203,18 @@ The total number of approvals contained within the transaction body cannot excee
 
 The `amount` must be specified in terms of the `decimals` value for the token. If `amount` is 0 the transaction will remove the `spender`'s allowance from the owner's account, thereby freeing an allowance for future use.
 
+A single NFT serial number can only be granted to one spender at a time. If an approval assigns a previously approved NFT serial number to a new user, the old user will have their approval removed. For example, if the following scenario were to occur:
+
+1. *userA* approves *userB* to use NFT *T* with serial *S*
+2. *userA* approves *userC* to use NFT *T* with serial *S*
+
+the end result will be that *userC* will hold an allowance to NFT *T* serial *S* while *userB* will have their allowance for NFT *T* serial *S* removed.
+
 In order to grant the `spender` access to *all* of the owner's instances of a particular NFT, the `approvedForAll` field in the `NftAllowance` message should be set to `true`.
 
 If the `spender` has already been granted `approvedForAll` for an owner's NFT and another transaction granting `approvedForAll` is sent for the same NFT, the transaction will be accepted and fees charged but it will effectively be a no-op. Similarly if multiple transactions to remove `approvedForAll` on the same NFT are received the effect will be idempotent.
+
+If the `spender` has been granted `approvedForAll` for an owner's NFT, the `spender` will in turn be permitted to approve an NFT serial number be spent by yet another spender. In other words, an `approvedForAll` spender effectively has the same privileges as the owner of the NFT. This behavior is consistent with the ERC721 implementation and is included here for backward compatibility of Ethereum smart contracts being ported over to Hedera.
 
 It is not an error if the total token amount in the owner's account is less than the specified allowance `amount`. If the `spender` tries to transfer more tokens than exists in the owner's account that transaction will fail.
 
@@ -206,7 +226,7 @@ It is not an error if the token is paused and an allowance approval is submitted
 
 The transaction must be signed by the owner's account and transaction fees will be paid by the owner only.
 
-Each account is limited to 100 allowances. This limit spans hbar, fungible and non-fungible token allowances. Each NFT serial number will count as a single allowance when computing the total allowances an account currently has.
+Each account is limited to 100 allowances. This limit spans hbar and fungible token allowances and non-fungible token `approvedForAll` grants. There is no limit on the number of NFT serial number approvals an owner may grant.
 
 The number of allowances set on an account will increase the auto renewal fee for the account. Conversely, removing allowances will decrease the auto renewal fee for the account.
 
@@ -257,9 +277,17 @@ This function will modify a series of existing allowances. The `cryptoAllowances
 
 The `amount` field in the `CryptoAllowance` and `TokenAllowance` messages is signed, thus this function can be used to increase or decrease an approved allowance.
 
-The `NftAllowance` message is used to modify the NFT serial number list for a spender. If the NFT serial number is *positive* then the NFT will be added to the approved list. Conversely if the serial number is *negative* the NFT will be removed from the approved list.
+The `NftAllowance` message is used to **add** NFT serial numbers for a spender. In order to **remove** an NFT serial number from an existing approval, the `CryptoDeleteAllowance` API should be used. The lack of an NFT removal mechanism in the `NftAllowance` message is due to the disparity in fee prices between the two calls (with `CryptoDeleteAllowance` being cheaper).
 
-If the caller wants to remove all serial numbers from the approved list the `approvedForAll` field should be set to `false`. If the `approvedForAll` field is set to `true`, the serial number list for the spender will also be purged as the spender is granted access to all NFT instances and an enumeration is not required.
+A single NFT serial number can only be granted to one spender at a time. If an adjustment assigns a previously approved NFT serial number to a new user, the old user will have their approval removed. For example, if the following scenario were to occur:
+
+1. *userA* approves *userB* to use NFT *T* with serial *R*
+2. *userA* approves *userC* to use NFT *T* with serial *S*
+3. *userA* adjusts *userC*'s allowance by adding NFT *T* with serial *R*
+
+the end result will be that *userC* will now have an allowance to NFT *T* serials *R* and *S* while *userB* will have their allowance for NFT *T* serial *R* removed.
+
+If the `spender` has been granted `approvedForAll` for an owner's NFT, the `spender` will in turn be permitted to approve an NFT serial number be spent by yet another spender. In other words, an `approvedForAll` spender effectively has the same privileges as the owner of the NFT. This behavior is consistent with the ERC721 implementation and is included here for backward compatibility of Ethereum smart contracts being ported over to Hedera.
 
 Each of the hbar/token approvals in the list do not need to refer to the same spender. The owner can modify different allowances for various spenders in a single transaction.
 
@@ -291,7 +319,67 @@ The allowance adjustment transaction will fail under the following circumstances
 - The token referenced in an NFT allowance is fungible.
 - Duplicate crypto or fungible token allowances for a spender are specified.
 - Duplicate NFT serial number allowances for a spender are specified.
+- A negative NFT serial number is specified.
 - No allowances are specified. 
+
+### Add CryptoDeleteAllowance API
+
+A new Hedera API will be added under the Crypto Service called `CryptoDeleteAllowance`. This function is called by the token owner to delete an existing allowance.
+
+```protobuf
+// new message
+message CryptoWipeAllowance {
+    AccountID owner = 1;
+}
+
+// new message
+message NftWipeAllowance {
+    TokenID token_id = 1;
+    AccountID owner = 2;
+    repeated int64 serial_numbers = 3;
+}
+
+// new message
+message TokenWipeAllowance {
+    TokenID token_id = 1;
+    AccountID owner = 2;
+}
+
+// new message
+message CryptoDeleteAllowanceTransactionBody {
+    repeated CryptoWipeAllowance cryptoAllowances = 1;
+    repeated NftWipeAllowance nftAllowances = 2;
+    repeated TokenWipeAllowance tokenAllowances = 3;
+}
+```
+
+This function will remove a series of existing allowances. The `cryptoAllowances`, `nftAllowances` and `tokenAllowances` fields specify removals of crypto allowances, non-fungible token allowances and fungible token allowances respectively.
+
+The `CryptoWipeAllowance` message is used to remove **all** hbar allowances granted by the owner.
+
+The `NftWipeAllowance` message is used to remove a number of NFT serial number allowances regardless of who the spender currently is.
+
+The `TokenWipeAllowance` message is used to remove **all** fungible token allowances granted by the owner for a specific token.
+
+A single `CryptoDeleteAllowanceTransactionBody` can specify the removal of allowances belonging to multiple owners so long as all parties sign the transaction.
+
+The transaction will not fail if the owner has not granted any allowances and a deletion is attempted.
+
+It is not an error if the owner's account is frozen or KYC-revoked for the specified token type.
+
+It is not an error if the token is paused and an allowance deletion is submitted.
+
+The transaction must be signed by the owner's account and transaction fees will be paid by the owner only.
+
+The deletion transaction will fail under the following circumstances:
+
+- The owner account is not associated with the specified token.
+- The owner account does not own the specified NFT serial numbers.
+- A serial number for an NFT does not exist.
+- The token referenced in an NFT allowance is fungible.
+- Duplicate deletions for the same fungible token are specified.
+- Duplicate NFT serial number deletions are specified.
+- No allowances are specified.
 
 ### Change CryptoTransfer to Support Approved Allowances
 
@@ -337,7 +425,7 @@ message NftTransfer {
    bool is_approval = 4;
 }
 ```
-To treat a transfer as an allowance transfer, we have to check if the transaction is signed by the debiting account. It is costly to expand signatures and verify this again during the balance adjustments. So to help us avoid this, a new boolean flag `isApproval` is added to the `AccountAmount` and `NftTransfer` messages which denote that the transfer has to be treated as allowance transfer if it set to `true`. This gives a lot of flexibility now as a transaction can contain a list of regular transfers and approved transfers, each potentially referencing a different token and/or owner.
+To treat a transfer as an allowance transfer, we have to check if the transaction is signed by the debiting account. It is costly to expand signatures and verify this again during the balance adjustments. So to help us avoid this, a new boolean flag `is_approval` is added to the `AccountAmount` and `NftTransfer` messages which denotes that the transfer has to be treated as allowance transfer if it set to `true`. This gives a lot of flexibility now as a transaction can contain a list of regular transfers and approved transfers, each potentially referencing a different token and/or owner.
 
 The `is_approval` field must be set to `true` for transfers that will involve an approved allowance otherwise a regular transfer will be assumed. For hbar and fungible transfers the `is_approval` field must be set on the debiting `AccountAmount` while for NFTs the `is_approval` field is set on the transfer message itself. Multiple owner accounts can be involved in a single transfer by setting `is_approval` to `true` for each of the owner `AccountAmount` messages.
 
@@ -400,7 +488,7 @@ message TransactionRecord {
 }
 ```
 
-The `crypto_adjustments`, `nft_adjustments` and `token_adjustments` fields will be populated for `CryptoAdjustApproval` transactions only and will contain the absolute/current value of the altered adjustments.
+The `crypto_adjustments`, `nft_adjustments` and `token_adjustments` fields will be populated for `CryptoAdjustApproval` transactions only and will contain the absolute/current value of the altered adjustments. The `nft_adjustments` field will only contain the `approvedForAll` grants made by the owner and **not** the individual NFT serial numbers that have been approved.
 
 ## Backwards Compatibility
 
@@ -427,6 +515,10 @@ The initial proposal introduced a new transaction API for transferring tokens th
 ### Support One Allowance in Approval API
 
 The approval API introduced in the initial proposal only permitted one allowance to be specified via a `oneof`, either an hbar or a token allowance. During internal design reviews, it was felt that since the `oneof` was the only field in the `CryptoApproveAllowanceTransactionBody` message, it would make more sense to separate the `CryptoAllowance` and `TokenAllowance` messages into distinct transaction body messages. However, doing so would necessitate a similar change to the `CryptoAdjustAllowanceTransactionBody` message to maintain the pattern of separating the hbar and token actions. An alternate solution was proposed to allow `CryptoApproveAllowanceTransactionBody` to specify both hbar and token approvals (as lists) within a single transaction. This approach also permits the caller to specify multiple approvals in bulk rather than issuing many calls.
+
+### Maintain List of Approved NFTs in Account
+
+The initial proposal maintained an `Account` mapping that would track all NFT serial numbers that were approved. Each map entry consisted of an NFT tokenId-spenderAccountId composite key and an array of NFT serial numbers. This approach would consume 16 bytes per NFT serial number in the worst case (assuming a different NFT token per serial number). The current approach does not keep track of the approved NFTs from the `Account`  but rather tracks the spender on the NFT serial number object itself and only incurs a cost of 4 bytes per NFT serial number. The loss of the NFT approval list on the `Account` is a potential usability issue but this same deficiency is found in the ERC721 implementation so migrating users will not be losing any functionality. Additionally this same query could be served by a mirror node API in the future.
 
 ## Open Issues
 

--- a/HIP/hip-336.md
+++ b/HIP/hip-336.md
@@ -9,7 +9,7 @@ last-call-date-time: 2021-02-14T07:00:00Z
 status: Approved
 created: 2022-01-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/337
-updated: 2022-04-08
+updated: 2022-04-11
 ---
 
 ## Abstract
@@ -105,7 +105,7 @@ It is not an error if either the spender or owner's accounts are frozen or KYC-r
 
 It is not an error if the token is paused and an allowance approval is submitted.
 
-The transaction must be signed by the owner's account and transaction fees will be paid by the owner only.
+The transaction must be signed by the owner's account and the account paying the transaction fees for the transaction. If the owner is paying the transaction fees only their signature is required.
 
 Each account is limited to 100 allowances. This limit spans hbar and fungible token allowances and non-fungible token `approved_for_all` grants. There is no limit on the number of NFT serial number approvals an owner may grant.
 
@@ -120,8 +120,6 @@ The allowance approval transaction will fail under the following circumstances:
 - The owner account does not own the specified NFT serial numbers.
 - A serial number for an NFT does not exist.
 - The token referenced in an NFT allowance is fungible.
-- Duplicate crypto or fungible token allowances for a spender are specified.
-- Duplicate NFT serial number allowances for a spender are specified.
 - No allowances are specified. 
 
 ### Add CryptoDeleteAllowance API
@@ -147,13 +145,15 @@ The `NftWipeAllowance` message is used to remove a number of NFT serial number a
 
 A single `CryptoDeleteAllowanceTransactionBody` can specify the removal of allowances belonging to multiple owners so long as all parties sign the transaction.
 
+The total number of NFT serial number deletions contained within the transaction body cannot exceed 20.
+
 The transaction will not fail if the owner has not granted any allowances and a deletion is attempted.
 
 It is not an error if the owner's account is frozen or KYC-revoked for the specified token type.
 
 It is not an error if the token is paused and an allowance deletion is submitted.
 
-The transaction must be signed by the owner's account and transaction fees will be paid by the owner only.
+The transaction must be signed by the owner's account and the account paying the transaction fees for the transaction. If the owner is paying the transaction fees only their signature is required.
 
 The deletion transaction will fail under the following circumstances:
 
@@ -161,7 +161,6 @@ The deletion transaction will fail under the following circumstances:
 - The owner account does not own the specified NFT serial numbers.
 - A serial number for an NFT does not exist.
 - The token referenced is fungible.
-- Duplicate NFT serial number deletions are specified.
 - No allowances are specified.
 
 ### Change CryptoTransfer to Support Approved Allowances
@@ -223,7 +222,7 @@ Custom fees are charged in exactly the same manner as regular transfers are.
 
 The spender's token allowance with the owner will be decreased by the transfer `amount` and will **not** include the customFees involved in the transfer. If the transfer `amount` will decrease the spender's allowance to zero, this transaction will effectively remove the spender's allowance from the owner’s account.
 
-If NFTs are transferred, the spender's claim on each of the serial numbers will be removed from the NFT object itself. Since the exact list of granted serial numbers is not tracked on the owner account, no allowance update needs to be made to the owner account.
+If NFTs are transferred, the spender's claim on each of the serial numbers will be removed from the NFT object itself. Since the exact list of granted serial numbers is not tracked on the owner account, no allowance update needs to be made to the owner account. Note that once an NFT is transferred from the owner's account, any associated allowance for the pertinent serial numbers will be removed. **An NFT approval will only exist so long as the owner maintains possession of the NFT serial number.**
 
 The transfer transaction will fail under the following circumstances:
 

--- a/HIP/hip-336.md
+++ b/HIP/hip-336.md
@@ -105,6 +105,8 @@ It is not an error if either the spender or owner's accounts are frozen or KYC-r
 
 It is not an error if the token is paused and an allowance approval is submitted.
 
+Duplicate approvals are permitted although they will count against the 20 approval limit per transaction. In the event of a duplicate approval, the last occurrence of the spender's approval will be used.
+
 The transaction must be signed by the owner's account and the account paying the transaction fees for the transaction. If the owner is paying the transaction fees only their signature is required.
 
 Each account is limited to 100 allowances. This limit spans hbar and fungible token allowances and non-fungible token `approved_for_all` grants. There is no limit on the number of NFT serial number approvals an owner may grant.
@@ -152,6 +154,8 @@ The transaction will not fail if the owner has not granted any allowances and a 
 It is not an error if the owner's account is frozen or KYC-revoked for the specified token type.
 
 It is not an error if the token is paused and an allowance deletion is submitted.
+
+Duplicate deletions are permitted although they will count against the 20 deletion limit per transaction. In the event of a duplicate deletion, the last occurrence of the spender's deletion will be used.
 
 The transaction must be signed by the owner's account and the account paying the transaction fees for the transaction. If the owner is paying the transaction fees only their signature is required.
 

--- a/HIP/hip-336.md
+++ b/HIP/hip-336.md
@@ -9,7 +9,7 @@ last-call-date-time: 2021-02-14T07:00:00Z
 status: Approved
 created: 2022-01-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/337
-updated: 2022-03-24
+updated: 2022-04-08
 ---
 
 ## Abstract
@@ -30,11 +30,7 @@ As a user, I want to enable another user the ability to spend all instances of a
 
 As a user, I want to modify or remove an allowance I have granted to another user so that I can manage that user's ability to spend my tokens over time.
 
-As a user, I want to remove all allowances I have granted without having to specify the spender account so that I can easily manage my approvals without issuing multiple queries first.
-
-As a user that has been granted an allowance, I want to be able to  transfer tokens owned by the owner account as if they were my tokens so that I can issue transfers on their behalf without them having to expose their private key.
-
-As a user, I want to query my account for the current token allowances that I have granted to other users so that I can monitor the activity of my delegates.
+As a user that has been granted an allowance, I want to be able to transfer tokens owned by the owner account as if they were my tokens so that I can issue transfers on their behalf without them having to expose their private key.
   
 ## Specification
 
@@ -45,124 +41,6 @@ The following terms will be used repeatedly throughout this section:
 - owner: the account that owns the tokens.
 - spender: the delegate account, the account being granted the power to spend the owner’s tokens.
 - recipient: the receiver of tokens when the spender issues a `CryptoTransfer` operation.
-
-### Add Allowance Balances to CryptoGetInfoResponse
-
-The repeated fields `granted_crypto_allowances`, `granted_nft_allowances` and `granted_token_allowances` will be added to the `CryptoGetInfoResponse` message. The `granted_crypto_allowances`, `granted_nft_allowances` and `granted_token_allowances` fields will contain hbar, non-fungible token and fungible token allowances respectively.
-
-```protobuf
-// new message
-message GrantedCryptoAllowance {
-    /**
-     * The account ID of the spender of the hbar allowance.
-     */
-    AccountID spender = 1;
-
-    /**
-     * The amount of the spender's allowance in tinybars.
-     */
-    int64 amount = 2;
-}
-
-// new message
-message GrantedTokenAllowance {
-    /**
-     * The token that the allowance pertains to.
-     */
-    TokenID token_id = 1;
-
-    /**
-     * The account ID of the token allowance spender.
-     */
-    AccountID spender = 2;
-
-    /**
-     * The amount of the spender's token allowance.
-     */
-    int64 amount = 3;
-}
-	
-// new message
-message GrantedNftAllowance {
-    /**
-     * The token that the allowance pertains to.
-     */
-    TokenID token_id = 1;
-
-    /**
-     * The account ID of the spender that has been granted access to all NFTs of the owner.
-     */
-    AccountID spender = 2;
-}
-
-// existing protobuf
-message CryptoGetInfoResponse {
-		
-	// existing nested message
-	message AccountInfo {
-		// existing fields
-		AccountID accountID = 1;
-		string contractAccountID = 2;
-		bool deleted = 3;
-		AccountID proxyAccountID = 4;
-		int64 proxyReceived = 6;
-		Key key = 7;
-		uint64 balance = 8;
-		uint64 generateSendRecordThreshold = 9 [deprecated=true];
-		uint64 generateReceiveRecordThreshold = 10 [deprecated=true];
-		bool receiverSigRequired = 11;
-		Timestamp expirationTime = 12;
-		Duration autoRenewPeriod = 13;
-		repeated LiveHash liveHashes = 14;
-		repeated TokenRelationship tokenRelationships = 15;
-		string memo = 16;
-		int64 ownedNfts = 17;
-		int32 max_automatic_token_associations = 18;
-		bytes alias = 19;
-		bytes ledger_id = 20;
-
-		// new fields
-		repeated GrantedCryptoAllowance granted_crypto_allowances = 21;
-		repeated GrantedNftAllowance granted_nft_allowances = 22;
-		repeated GrantedTokenAllowance granted_token_allowances = 23;
-	}
-
-	// existing fields
-	ResponseHeader header = 1;
-	AccountInfo accountInfo = 2;
-}
-```
-
-The `GrantedTokenAllowance` message will contain the allowance information for a single fungible token tranferable by the `spender`.
-
-The `GrantedNftAllowance` message will contain the allowance information for a non-fungible token. The listed `spender` will be approved to spend all of the serial numbers owned by the owner for the specific NFT token. The list of serial numbers that have been approved to spenders will **not** be returned as this information is not tracked on the owner's account. This behavior is consistent with the ERC721 implementation and should not be a surprise to Ethereum developers.
-
-Only allowances with a non-zero value will be returned.
-
-The `spender`'s allowance will change as tokens are spent or additional allowances are approved by the token owner.
-
-### Add Spender ID to TokenNftInfo
-
-The current spender that has been approved access to an NFT serial number will be added to the `TokenNftInfo` message that is returned as part of the `TokenGetNftInfoResponse` and `TokenGetNftInfosResponse`.
-
-```protobuf
-// existing message
-message TokenNftInfo {
-	// existing fields
-	NftID nftID = 1;
-	AccountID accountID = 2;	// current owner
-	Timestamp creationTime = 3;
-	bytes metadata = 4;
-	bytes ledger_id = 5;
- 
-	// new field
-	AccountID spender_id = 6;
-}
-```
-
-Only one spender can be assigned to an NFT serial number at a time.
-
-If the NFT serial number has not been approved to spend by an account, the `spender_id` field will not be included.
 
 ### Add CryptoApproveAllowance API
 
@@ -186,8 +64,9 @@ message NftAllowance {
 	TokenID tokenId = 1;
 	AccountID owner = 2;
 	AccountID spender = 3;
-	repeated int64 serialNumbers = 4;
-	google.protobuf.BoolValue approvedForAll = 5;
+	repeated int64 serial_numbers = 4;
+	google.protobuf.BoolValue approved_for_all = 5;
+	AccountID delegating_spender = 6;
 }
 	
 message CryptoApproveAllowanceTransactionBody {
@@ -197,7 +76,7 @@ message CryptoApproveAllowanceTransactionBody {
 }
 ```
 
-This function contains a list of hbar and/or token approval messages. The `CryptoAllowance` and `TokenAllowance` messages will set an allowance of `amount` fungible tokens or hbar that can be transferred from the owner's account to another account by the `spender` account. The `NftAllowance` message sets an allowance for specific NFT serial numbers within the owner's account. Each of the hbar/token approvals in the list do not need to refer to the same spender. The owner can establish different allowances for various spenders in a single transaction.
+This function contains a list of hbar and/or token approval messages. The `CryptoAllowance` and `TokenAllowance` messages will set an allowance of `amount` hbar or fungible tokens that can be transferred from the owner's account to another account by the `spender` account. The `NftAllowance` message sets an allowance for specific NFT serial numbers within the owner's account. Each of the hbar/token approvals in the list do not need to refer to the same spender. The owner can establish different allowances for various spenders in a single transaction.
 
 The total number of approvals contained within the transaction body cannot exceed 20. This number includes all hbar, fungible and non-fungible token approvals. Note that each NFT serial number counts as a single approval, hence a transaction granting 20 serial numbers to a spender will use all of the approvals permitted for the transaction.
 
@@ -210,11 +89,13 @@ A single NFT serial number can only be granted to one spender at a time. If an a
 
 the end result will be that *userC* will hold an allowance to NFT *T* serial *S* while *userB* will have their allowance for NFT *T* serial *S* removed.
 
-In order to grant the `spender` access to *all* of the owner's instances of a particular NFT, the `approvedForAll` field in the `NftAllowance` message should be set to `true`.
+In order to grant the `spender` access to *all* of the owner's instances of a particular NFT, the `approved_for_all` field in the `NftAllowance` message should be set to `true`.
 
-If the `spender` has already been granted `approvedForAll` for an owner's NFT and another transaction granting `approvedForAll` is sent for the same NFT, the transaction will be accepted and fees charged but it will effectively be a no-op. Similarly if multiple transactions to remove `approvedForAll` on the same NFT are received the effect will be idempotent.
+If the `spender` has already been granted `approved_for_all` for an owner's NFT and another transaction granting `approved_for_all` is sent for the same NFT, the transaction will be accepted and fees charged but it will effectively be a no-op. Similarly if multiple transactions to remove `approved_for_all` on the same NFT are received the effect will be idempotent.
 
-If the `spender` has been granted `approvedForAll` for an owner's NFT, the `spender` will in turn be permitted to approve an NFT serial number be spent by yet another spender. In other words, an `approvedForAll` spender effectively has the same privileges as the owner of the NFT. This behavior is consistent with the ERC721 implementation and is included here for backward compatibility of Ethereum smart contracts being ported over to Hedera.
+If the `spender` has been granted `approved_for_all` for an owner's NFT, the `spender` will in turn be permitted to approve an NFT serial number be spent by yet another spender. In other words, an `approved_for_all` spender effectively has the same privileges as the owner of the NFT. This behavior is consistent with the ERC721 implementation and is included here for backward compatibility of Ethereum smart contracts being ported over to Hedera. For signature checking performance considerations, the `spender` must set the `delegating_spender` field to their account and sign the transaction when spending using an `approved_for_all` privilege. Failure to do so will result in an `INVALID_SIGNATURE` error. If the `spender` does not set the `delegating_spender` field, the transaction will be treated as if it were a regular approval, meaning the `owner` signature will be required.
+
+For hbar and fungible token approvals, the amounts specified in the transaction will overwrite the current value of the `spender`'s allowance with the `owner`. For NFT approvals, each approval will add the specified serial numbers to the `spender`'s allowance.
 
 It is not an error if the total token amount in the owner's account is less than the specified allowance `amount`. If the `spender` tries to transfer more tokens than exists in the owner's account that transaction will fail.
 
@@ -226,7 +107,7 @@ It is not an error if the token is paused and an allowance approval is submitted
 
 The transaction must be signed by the owner's account and transaction fees will be paid by the owner only.
 
-Each account is limited to 100 allowances. This limit spans hbar and fungible token allowances and non-fungible token `approvedForAll` grants. There is no limit on the number of NFT serial number approvals an owner may grant.
+Each account is limited to 100 allowances. This limit spans hbar and fungible token allowances and non-fungible token `approved_for_all` grants. There is no limit on the number of NFT serial number approvals an owner may grant.
 
 The number of allowances set on an account will increase the auto renewal fee for the account. Conversely, removing allowances will decrease the auto renewal fee for the account.
 
@@ -243,123 +124,26 @@ The allowance approval transaction will fail under the following circumstances:
 - Duplicate NFT serial number allowances for a spender are specified.
 - No allowances are specified. 
 
-### Add CryptoAdjustAllowance API
-
-A new Hedera API will be added under the Crypto Service called `CryptoAdjustAllowance`. This function is called by the token owner to modify an existing allowance for a spender account.
-
-```protobuf
-message CryptoAllowance {
-	AccountID spender = 1;
-	int64 amount = 2;
-}
-
-message TokenAllowance {
-	TokenID tokenId = 1;
-	AccountID spender = 2;
-	int64 amount = 3;
-}
-
-message NftAllowance {
-	TokenID tokenId = 1;
-	AccountID spender = 2;
-	repeated int64 serialNumbers = 3;
-	google.protobuf.BoolValue approvedForAll = 4;
-}
-
-message CryptoAdjustAllowanceTransactionBody {
-	repeated CryptoApproval cryptoAllowances = 1;
-	repeated NftAllowance nftAllowances = 2;
-	repeated TokenAllowance tokenAllowances = 3;
-}
-```
-
-This function will modify a series of existing allowances. The `cryptoAllowances`, `nftAllowances` and `tokenAllowances` fields specify adjustments to crypto allowances, non-fungible token allowances and fungible token allowances respectively.
-
-The `amount` field in the `CryptoAllowance` and `TokenAllowance` messages is signed, thus this function can be used to increase or decrease an approved allowance.
-
-The `NftAllowance` message is used to **add** NFT serial numbers for a spender. In order to **remove** an NFT serial number from an existing approval, the `CryptoDeleteAllowance` API should be used. The lack of an NFT removal mechanism in the `NftAllowance` message is due to the disparity in fee prices between the two calls (with `CryptoDeleteAllowance` being cheaper).
-
-A single NFT serial number can only be granted to one spender at a time. If an adjustment assigns a previously approved NFT serial number to a new user, the old user will have their approval removed. For example, if the following scenario were to occur:
-
-1. *userA* approves *userB* to use NFT *T* with serial *R*
-2. *userA* approves *userC* to use NFT *T* with serial *S*
-3. *userA* adjusts *userC*'s allowance by adding NFT *T* with serial *R*
-
-the end result will be that *userC* will now have an allowance to NFT *T* serials *R* and *S* while *userB* will have their allowance for NFT *T* serial *R* removed.
-
-If the `spender` has been granted `approvedForAll` for an owner's NFT, the `spender` will in turn be permitted to approve an NFT serial number be spent by yet another spender. In other words, an `approvedForAll` spender effectively has the same privileges as the owner of the NFT. This behavior is consistent with the ERC721 implementation and is included here for backward compatibility of Ethereum smart contracts being ported over to Hedera.
-
-Each of the hbar/token approvals in the list do not need to refer to the same spender. The owner can modify different allowances for various spenders in a single transaction.
-
-This message body is exactly the same as `CryptoApproveAllowanceTransactionBody` but is duplicated in case adjustment specific changes are required in the future.
-
-The `amount` must be specified in terms of the `decimals` value for the token.  If the addition of `amount` to the `spender`'s current allowance equals 0, the transaction will remove the `spender`'s allowance from the owner's account, thereby freeing an allowance for future use.
-
-If the `spender` does not have an allowance established with the caller for the specified token and the `amount` is positive, this transaction will implicitly create a new approved allowance for the `spender` for `amount` tokens.
-
-It is not an error if the total token amount in the caller’s account is less than the `spender`'s current allowance plus the specified `amount`.
-
-It *IS* an error if an NFT allowance specifies a serial number that the owner does not have possession of.
-
-It is not an error if either the spender or owner's accounts are frozen or KYC-revoked for the specified token type. If the `spender` tries to transfer a token under these conditions, the transaction will fail anyway.
-
-It is not an error if the token is paused and an allowance adjustment is submitted.
-
-The transaction must be signed by the owner's account and transaction fees will be paid by the owner only.
-
-The allowance adjustment transaction will fail under the following circumstances:
-
-- The `spender` account is the same as the owner's account.
-- The `amount` will exceed the maximum supply of the token.
-- The `spender`'s current allowance plus the `amount` will exceed the maximum supply of the token.
-- The `spender`'s current allowance plus the `amount` will result in a negative number.
-- The owner account is not associated with the specified token.
-- The owner account does not own the specified NFT serial numbers.
-- A serial number for an NFT does not exist.
-- The token referenced in an NFT allowance is fungible.
-- Duplicate crypto or fungible token allowances for a spender are specified.
-- Duplicate NFT serial number allowances for a spender are specified.
-- A negative NFT serial number is specified.
-- No allowances are specified. 
-
 ### Add CryptoDeleteAllowance API
 
-A new Hedera API will be added under the Crypto Service called `CryptoDeleteAllowance`. This function is called by the token owner to delete an existing allowance.
+A new Hedera API will be added under the Crypto Service called `CryptoDeleteAllowance`. This function is called by the token owner to delete allowances for NFTs only. In order to delete an existing hbar or fungible token allowance the `CryptoApproveAllowance` API should be used with an `amount` of 0.
 
 ```protobuf
-// new message
-message CryptoWipeAllowance {
-    AccountID owner = 1;
-}
 
 // new message
-message NftWipeAllowance {
+message NftRemoveAllowance {
     TokenID token_id = 1;
     AccountID owner = 2;
     repeated int64 serial_numbers = 3;
 }
 
 // new message
-message TokenWipeAllowance {
-    TokenID token_id = 1;
-    AccountID owner = 2;
-}
-
-// new message
 message CryptoDeleteAllowanceTransactionBody {
-    repeated CryptoWipeAllowance cryptoAllowances = 1;
-    repeated NftWipeAllowance nftAllowances = 2;
-    repeated TokenWipeAllowance tokenAllowances = 3;
+    repeated NftRemoveAllowance nftAllowances = 2;
 }
 ```
 
-This function will remove a series of existing allowances. The `cryptoAllowances`, `nftAllowances` and `tokenAllowances` fields specify removals of crypto allowances, non-fungible token allowances and fungible token allowances respectively.
-
-The `CryptoWipeAllowance` message is used to remove **all** hbar allowances granted by the owner.
-
 The `NftWipeAllowance` message is used to remove a number of NFT serial number allowances regardless of who the spender currently is.
-
-The `TokenWipeAllowance` message is used to remove **all** fungible token allowances granted by the owner for a specific token.
 
 A single `CryptoDeleteAllowanceTransactionBody` can specify the removal of allowances belonging to multiple owners so long as all parties sign the transaction.
 
@@ -376,8 +160,7 @@ The deletion transaction will fail under the following circumstances:
 - The owner account is not associated with the specified token.
 - The owner account does not own the specified NFT serial numbers.
 - A serial number for an NFT does not exist.
-- The token referenced in an NFT allowance is fungible.
-- Duplicate deletions for the same fungible token are specified.
+- The token referenced is fungible.
 - Duplicate NFT serial number deletions are specified.
 - No allowances are specified.
 
@@ -440,7 +223,7 @@ Custom fees are charged in exactly the same manner as regular transfers are.
 
 The spender's token allowance with the owner will be decreased by the transfer `amount` and will **not** include the customFees involved in the transfer. If the transfer `amount` will decrease the spender's allowance to zero, this transaction will effectively remove the spender's allowance from the owner’s account.
 
-If NFTs are transferred, the relevant serial numbers will be removed from the spender's NFT allowance with the owner. If the transfer will result in an empty NFT allowance list, this transaction will effectively remove the spender's NFT allowance from the owner's account.
+If NFTs are transferred, the spender's claim on each of the serial numbers will be removed from the NFT object itself. Since the exact list of granted serial numbers is not tracked on the owner account, no allowance update needs to be made to the owner account.
 
 The transfer transaction will fail under the following circumstances:
 
@@ -456,45 +239,32 @@ The transfer transaction will fail under the following circumstances:
 - Either the owner or recipient accounts are frozen for the specified token.
 - The specified `token` is paused.
 
-### Change TransactionRecord to Contain Current Allowance Balance
+### Add Spender ID to TokenNftInfo
 
-The current balance for hbar and token allowances will be added to the `TransactionRecord` message. This information is required for the mirror node to track the correct allowances for a spender. The mirror node will have the allowances granted in a `CryptoApproveAllowance` but these values will not be modified on an on-going basis as `CryptoTransfer` transactions are executed, hence if adjustments are applied as deltas the mirror node will have an incorrect allowance value after `CryptoAdjustAllowance`.
+The current spender that has been approved access to an NFT serial number will be added to the `TokenNftInfo` message that is returned as part of the `TokenGetNftInfoResponse` and `TokenGetNftInfosResponse`.
 
 ```protobuf
-message TransactionRecord {
+// existing message
+message TokenNftInfo {
 	// existing fields
-	TransactionReceipt receipt = 1;
-	bytes transactionHash = 2;
-	Timestamp consensusTimestamp = 3;
-	TransactionID transactionID = 4;
-	string memo = 5;
-	uint64 transactionFee = 6;
-	oneof body {
-		ContractFunctionResult contractCallResult = 7;
-		ContractFunctionResult contractCreateResult = 8;
-	}
-	TransferList transferList = 10;
-	repeated TokenTransferList tokenTransferLists = 11;
-	ScheduleID scheduleRef = 12;
-	repeated AssessedCustomFee assessed_custom_fees = 13;
-	repeated TokenAssociation automatic_token_associations = 14;
-	Timestamp parent_consensus_timestamp = 15;
-	bytes alias = 16;
-	
-	// new fields
-	repeated CryptoAllowance crypto_adjustments = 17;
-	repeated NftAllowance nft_adjustments = 18;
-	repeated TokenAllowance token_adjustments = 19;
+	NftID nftID = 1;
+	AccountID accountID = 2;	// current owner
+	Timestamp creationTime = 3;
+	bytes metadata = 4;
+	bytes ledger_id = 5;
+ 
+	// new field
+	AccountID spender_id = 6;
 }
 ```
 
-The `crypto_adjustments`, `nft_adjustments` and `token_adjustments` fields will be populated for `CryptoAdjustApproval` transactions only and will contain the absolute/current value of the altered adjustments. The `nft_adjustments` field will only contain the `approvedForAll` grants made by the owner and **not** the individual NFT serial numbers that have been approved.
+Only one spender can be assigned to an NFT serial number at a time.
+
+If the NFT serial number has not been approved to spend by an account, the `spender_id` field will not be included.
 
 ## Backwards Compatibility
 
-The CryptoGetInfo query will return the same account information as before plus the newly added fields `crypto_allowances`, `nft_allowances` and `token_allowances`. Clients that are not interested in the account's approved allowances can safely ignore these fields.
-
-The CryptoApproveAllowance and CryptoAdjustAllowance transactions are new additions to the API and will not have any backward compatibility issues to address.
+The CryptoApproveAllowance and CryptoDeleteAllowance transactions are new additions to the API and will not have any backward compatibility issues to address.
 
 The CryptoTransfer transaction is not incurring any API/signature changes but the backend implementation is being changed to accommodate the proposed allowance/approval mechanism. Transactions submitted by the spender that seek to utilize the allowance feature before the feature is enabled will fail validation since the owner has not signed the transaction. Once the feature is enabled, regular transfers will still be handled in the same manner and spender approved transfers will also be permitted.
 
@@ -504,21 +274,17 @@ The approved allowances APIs discussed herein were inspired by ERC-20. The attac
 
 ## Rejected Ideas
 
-### Introduce New API for Querying Allowances
-
-The initial proposal introduced a new query API that was similar to the ERC-20 `allowance()` method. While copying this method in the Hedera API would make for an easier transition for Ethereum developers, many Hedera engineers felt that the API should be more minimal and existing calls reused as much as possible.
-
 ### Introduce New API for Approved Transfers
 
 The initial proposal introduced a new transaction API for transferring tokens that would support an approved transfer list. This API would only allow a spender to submit approved transfers and did not include regular crypto or token transfers. During design review several Hedera engineers felt that there should only be a single transfer API rather than two. Upon further inspection it was found that the current CryptoTransfer message format could support approved transfers in addition to regular transfers.
 
 ### Support One Allowance in Approval API
 
-The approval API introduced in the initial proposal only permitted one allowance to be specified via a `oneof`, either an hbar or a token allowance. During internal design reviews, it was felt that since the `oneof` was the only field in the `CryptoApproveAllowanceTransactionBody` message, it would make more sense to separate the `CryptoAllowance` and `TokenAllowance` messages into distinct transaction body messages. However, doing so would necessitate a similar change to the `CryptoAdjustAllowanceTransactionBody` message to maintain the pattern of separating the hbar and token actions. An alternate solution was proposed to allow `CryptoApproveAllowanceTransactionBody` to specify both hbar and token approvals (as lists) within a single transaction. This approach also permits the caller to specify multiple approvals in bulk rather than issuing many calls.
+The approval API introduced in the initial proposal only permitted one allowance to be specified via a `oneof`, either an hbar or a token allowance. During internal design reviews, it was felt that since the `oneof` was the only field in the `CryptoApproveAllowanceTransactionBody` message, it would make more sense to separate the `CryptoAllowance` and `TokenAllowance` messages into distinct transaction body messages. Additionally, specifying both hbar and token approvals (as lists) within a single transaction permits the caller to specify multiple approvals in bulk rather than issuing many calls.
 
 ### Maintain List of Approved NFTs in Account
 
-The initial proposal maintained an `Account` mapping that would track all NFT serial numbers that were approved. Each map entry consisted of an NFT tokenId-spenderAccountId composite key and an array of NFT serial numbers. This approach would consume 16 bytes per NFT serial number in the worst case (assuming a different NFT token per serial number). The current approach does not keep track of the approved NFTs from the `Account`  but rather tracks the spender on the NFT serial number object itself and only incurs a cost of 4 bytes per NFT serial number. The loss of the NFT approval list on the `Account` is a potential usability issue but this same deficiency is found in the ERC721 implementation so migrating users will not be losing any functionality. Additionally this same query could be served by a mirror node API in the future.
+The initial proposal maintained an `Account` mapping that would track all NFT serial numbers that were approved. Each map entry consisted of an NFT tokenId-spenderAccountId composite key and an array of NFT serial numbers. This approach would consume 16 bytes per NFT serial number in the worst case (assuming a different NFT token per serial number). The current approach does not keep track of the approved NFTs from the `Account` but rather tracks the spender on the NFT serial number object itself and only incurs a cost of 4 bytes per NFT serial number. The loss of the NFT approval list on the `Account` is a potential usability issue but this same deficiency is found in the ERC721 implementation so migrating users will not be losing any functionality. Additionally this same query could be served by a mirror node API in the future.
 
 ## Open Issues
 


### PR DESCRIPTION
Signed-off-by: Albert Tam <albert.tam@hedera.com>

**Description**:
Changes related to ERC721 compatibility:
- Separate NFT serial number + approvedForAll semantics, state is kept independent now.
- Only permit one spender per NFT serial number, new approvals will remove the old approval.
- Added CryptoDeleteAllowance to match 0-address approval in ERC721
- Add spender field to NftInfo as this state is now tracked on the MerkleUniqueToken instead of the Account.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
