### PR TITLE
Update staking HIP with more implementation details

### DIFF
--- a/HIP/hip-406.md
+++ b/HIP/hip-406.md
@@ -234,7 +234,8 @@ If rewards are activated (because `0.0.800` reached the threshold at some time i
         // stakePeriodStart + 2 up to todayNumber - 1, for which it is guaranteed to have held its 
         // current stake.
         offeredReward += (account.balance + account.stakedToMe) / 100_000_000 * 
-            stakedNode.rewardSumHistory[0] - stakedNode.rewardSumHistory[todayNumber - 1 - (stakePeriodStart + 1)];
+            (stakedNode.rewardSumHistory[0] 
+                - stakedNode.rewardSumHistory[todayNumber - 1 - (stakePeriodStart + 1)]);
     }
     reward = account.declinedReward ? 0 : offeredReward;
     account.balance += reward; //transfer the reward to the account 

--- a/HIP/hip-406.md
+++ b/HIP/hip-406.md
@@ -106,6 +106,10 @@ Alice stakes her account containing 1 hbar to a node and then loses her key. Eve
 
 A node has a max stake of 30, but Alice stakes 100 to it and Bob stakes 200 to it, so the total stake is 300. Only 30 of that 300 will count, which is one tenth. So Alice earns rewards as if she had staked only 10, and Bob earns rewards as if he had staked only 20, and the node gains weight in consensus as if only 30 had been staked to it. The excess staking is ignored. (These numbers are unrealistic, but are just chosen for this example to make the math simple).
 
+### 19. Accounts stake non-whole number of hbars 
+
+Alice stakes 2.5 hbars to a node. The node's `stakeRewarded` increases by only 2 hbars, and Alice is rewarded only for each whole hbar she has staked. Bob then stakes 2.5 hbars to Alice. Now the `stakeRewarded` Alice contributes to her node increases by 3, because 2.5 + 2.5 = 5 hbars, which is a whole number. This is a general principle: Nodes and accounts accumulate stake and rewards per whole hbar, and fractions are rounded down.
+
 ## Specification
 
 Each node in the network shares responsibility for securing the network. Not all nodes have the same inherent trustworthiness. *Stake* is used to as an indication for trustworthiness. Nodes with greater *stake* are deemed to be more trustworthy as determined by the users of the network. *Stake* is expressed as an amount in hbars. The stake is used to compute a node’s contribution to consensus, is counted when collecting signatures on streaming record files, and will affect a node’s share in the signature for the state. When determining a *strong minority* or *super majority* of the network for consensus or other uses, we use the stake of each node as a fraction of the total staked to all nodes to determine whether we have at least 1/3 of the *stake* of the network or greater than 2/3 of the *stake* of the network, rather than just counting 1/3 or 2/3 of the *nodes* on the network.
@@ -156,6 +160,8 @@ The following fields on the account are used for staking:
   - `AccountID stakedAccount` (value ≥ -1); the account to which the account is staking. If not staked to an account, the value is null. The default value is null. It can never happen that `stakedAccount` is non-null and `stakedNode` is nonnegative at the same time.
   - `boolean declineReward` true if the account declines receiving a staking reward. Default is false.
   - `long stakePeriodStart` (value ≥ -1) the staking period during which either the staking settings for this account changed (such as starting staking or changing `stakedNode`) or the most recent reward was earned, whichever is later. If this account is not currently staked to a node, then the value is -1. 
+  - `boolean rewardedSinceLastStakingChange` true if this account has claimed a reward since the last time its staking settings changed (includes the degenerate case of claiming a zero reward by changing the amount staked before contributing to consensus for a full period).
+  - `long stakeAtStartOfLastRewardedPeriod` (value ≥ 0) if `rewardedSinceLastStakingChange` is true, this field is the sum of the account's `balance` and `stakedToMe` fields at the start of the latest staking period in which it claimed a reward; if `rewardedSinceLastStakingChange` is false, this field provides no information.
 
 The account’s `balance` is not a new field, it is the same as currently exists with the same rules and semantics as currently exist. It holds the current balance of the account, in tinybars.
 
@@ -203,12 +209,38 @@ If rewards are activated (because `0.0.800` reached the threshold at some time i
 
 6. Otherwise, if it is any other case (`-1 < stakePeriodStart < todayNumber - 1`), then transfer a reward from the staking reward account (`0.0.800`) to this account, then set `stakePeriodStart` to `todayNumber-1`. The value of `stakedNode.rewardSumHistory[todayNumber - 1 - t]` is the total reward in tinybars that has been earned by those staking to node `stakedNode` per token staked, throughout all of history up to and including the reward for the full day `t`. So `stakedNode.rewardSumHistory[0]` is the reward for all days up to and including the full day `todayNumber - 1`. There is not yet an entry that includes the reward for `todayNumber`, because today is not yet finished. The account should rewarded for the first day of staking that hasn't yet received an award (`stakePeriodStart` minus the previous day), proportional to non-ignored, rewarded balances at the start of that day, plus rewards for all full days thereafter. So, if `account.balance` is the balance of this account at the start of this transaction (before it might have been changed by running the smart contract), then the amount of the reward is calculated as:
 ```
-    reward = declinedReward ? 0 : 
-                account.balance * (  stakedNode.rewardSumHistory[ todayNumber - 1 - (todayNumber - 1) ] 
-                                   - stakedNode.rewardSumHistory[ todayNumber - 1 - (stakePeriodStart - 1) ]);
+    offeredReward = 0;
+    if (!rewardedSinceLastStakingChange) {
+        // This account's stake has not changed since day stakePeriodStart, when it first started
+        // staking to a node but was not eligible to earn a reward. So we can reward it based on
+        // its current stake as below. (To see why the second rewardSumHistory index is correct, note 
+        // it clearly holds for the base case that stakePeriodStart = todayNumber - 2, since then we 
+        // want to reward for only day todayNumber - 1 via rewardSumHistory[0] - rewardSumHistory[1]. 
+        // Smaller values of stakePeriodStart follow by induction.)
+        offeredReward = (account.balance + account.stakedToMe) / 100_000_000 * 
+            (stakedNode.rewardSumHistory[0] 
+                - stakedNode.rewardSumHistory[todayNumber - 1 - stakePeriodStart]);
+    } else {
+        // This account claimed a (possibly zero) reward in day stakePeriodStart + 1, and may have
+        // changed its stake in the process. So we need to reward it for that day based on the 
+        // stake we remember it it had at the start of the day, not the stake that it has now. (To
+        // see why the rewardSumHistory indices are correct, again start with the base case that
+        // stakePeriodStart = todayNumber - 2, so that once more we want to reward only for 
+        // todayNumber - 1 via rewardSumHistory[0] - rewardSumHistory[1].)
+        offeredReward += account.stakeAtStartOfLastRewardedPeriod / 100_000_000 *
+            (stakedNode.rewardSumHistory[todayNumber - 1 - (stakePeriodStart + 1)] 
+                - stakedNode[todayNumber - 1 - stakePeriodStart]);
+        // And now we need to _also_ reward it for the (possibly empty) set of days from 
+        // stakePeriodStart + 2 up to todayNumber - 1, for which it is guaranteed to have held its 
+        // current stake.
+        offeredReward += (account.balance + account.stakedToMe) / 100_000_000 * 
+            stakedNode.rewardSumHistory[0] - stakedNode.rewardSumHistory[todayNumber - 1 - (stakePeriodStart + 1)];
+    }
+    reward = account.declinedReward ? 0 : offeredReward;
     account.balance += reward; //transfer the reward to the account 
     pendingRewards -= reward; //that amount is no longer "pending"
 ```
+
 5. Execute the transaction (if it wasn't already executed in step 2).
 
 6. Let `delta` be the amount by which `balance` increased due to the reward or as a result of executing the transaction. If `delta` is nonzero, then add `delta` to the appropriate field of the staking target. That is the `stakedToMe` field of an account it is staked to, and the `stakedRewarded` field of a node it is staked to (if `declineReward == false`), or the `stakedNotRewarded` field of a node it is staked to (if `declineReward == true`). If it is staked to an account that is staked to a node, then also add it to the appropriate field of that node, which is either `stakedNotRewarded` or `stakedRewarded`, depending on the `declineReward` field of the targeted account.
@@ -222,15 +254,26 @@ At the end of each staking period, the nodes will be updated. If the staking per
 ```
     // total tinybars of reward earned by all stakers for the staking period now ending
     long rate = max(0, min(accountBalance(0.0.800) - pendingRewards, stakingRewardRate)); 
+    // The tinybars earned per hbar for stakers who are staked to a node whose total
+    // stakedRewarded is in the range [minStake, maxStake]
+    long perHbarRate = rate / (totalStakedRewardStart / 100_000_000);
     
     for each node {
         for (i=365; i>0; i--) //push a day onto the history (latest reward is zero, but updated below)
             node.rewardSumHistory[i] = node.rewardSumHistory[i-1];
-        //if this node was "active", then it should give rewards for this staking period
-        if (node.numRoundsWithJudge / numRoundsInPeriod >= activeThreshold)
-            long nodeReward = rate * node.stakedRewardedStart / totalStakedRewardedStart / 100_000_000;
-			pendingRewards += nodeReward;
-            node.rewardSumHistory[0] += nodeReward;
+        long perHbarRateThisNode = 0;
+        // If this node was "active", and it had non-zero stakedReward at the start of the ending staking period,
+        // then it should give rewards for this staking period
+        if (node.numRoundsWithJudge / numRoundsInPeriod >= activeThreshold && node.stakedRewardStart > 0) {
+            perHbarRateThisNode = perHbarRate;    
+            // But if the node received more the maximum stakeToReward, "down-scale" its reward rate to 
+            // ensure accounts staking to this node will receive a fraction of the total rewards that does  
+            // not exceed node.stakedRewardStart / totalStakedRewardedStart
+            if (node.stakeToReward > node.maxStake) {
+                nodePerHbarRate = (nodePerHbarRate * node.maxStake) / node.stakeToReward;
+            }
+        }
+        node.rewardSumHistory[0] += perHbarRateThisNode
     }
     totalStakedRewardStart = 0;
     totalStakedNoRewardStart = 0;

--- a/HIP/hip-406.md
+++ b/HIP/hip-406.md
@@ -274,7 +274,8 @@ At the end of each staking period, the nodes will be updated. If the staking per
                 nodePerHbarRate = (nodePerHbarRate * node.maxStake) / node.stakeToReward;
             }
         }
-        node.rewardSumHistory[0] += perHbarRateThisNode
+        node.rewardSumHistory[0] += perHbarRateThisNode;
+        pendingRewards += (node.stakeToReward / 100_000_000) * perHbarRateThisNode;
     }
     totalStakedRewardStart = 0;
     totalStakedNoRewardStart = 0;


### PR DESCRIPTION
**Description**:
Updates pseudocode with more implementation details, including:
 - Rounding of staked amounts to whole hbars.
 - Use of `rewardedSinceLastStakingChange` and `stakeAtStartOfLastRewardedPeriod` fields to ensure `pendingRewards` is always exact.
 - Use of node-specific reward rates (including down-scaled rates for nodes with stake greater than `maxStake`).