### PR TITLE
Update hip-1 to add new status called `Stagnant`

### DIFF
--- a/HIP/hip-1.md
+++ b/HIP/hip-1.md
@@ -223,9 +223,8 @@ Each HIP must begin with a header preamble in a table format. The headers must a
 
 - hip: HIP number (this is determined by the PR number and set by the editor)
 - title: HIP title
-- author: a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s).
-- working-group\*: a list of the technical and business stakeholders' name(s) and/or username(s), or name(s) and email(s).
-- implementer: person or group of people willing to implement the work
+- author: a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s)
+- working-group\*: a list of the technical and business stakeholders' name(s) and/or username(s), or name(s) and email(s)
 - type: Standards Track | Informational | Process
 - category\*: Core | Service | API | Mirror | Application
 - needs-council-approval: Yes | No

--- a/HIP/hip-1.md
+++ b/HIP/hip-1.md
@@ -160,6 +160,7 @@ The possible paths of the status of HIPs are as follows:
 - __Review__ - A HIP Author marks a HIP as ready for and requesting Editorial Review.
 - __Deferred__ - Any HIP in Draft or Review if inactive for a period of 6 months or greater is moved to Deferred. A HIP may be resurrected from this state by Authors or HIP Editors through moving it back to Draft.
 - __Withdrawn__ - The HIP Author(s) have withdrawn the proposed HIP. This state has finality and can no longer be resurrected using this HIP number. If the idea is pursued at a later date - it is considered a new proposal.
+- __Stagnant__ - Any HIP that has failed to receive enough community support and fails to get an implementer willing to do the work four weeks after the creation date will be considered Stagnant. Community support defines the level of engagement a HIP's related discussion has. The discussion should have at least fifteen upvotes and more than three unique responders to qualify as sufficient community support. If no discussion link is defined, the HIP will be considered Stagnant four weeks after the HIP creation date. If a HIP has a status of Stagnant for six months, it automatically moves to Rejected status. At any point during this time, a HIP can be resurrected back into its previous state (Draft/Review) if it receives enough community support, as outlined in this document.
 - __Rejected__ - Throughout the discussion of a HIP, various ideas will be proposed which are not accepted. Those rejected ideas should be recorded along with the reasoning as to why they were rejected. This both helps record the thought process behind the final version of the HIP and prevents people from bringing up the same rejected idea again in subsequent discussions.
 - __Last Call__ - This is the final review window for a HIP before moving to "Accepted". A HIP editor will assign Last Call status and set a review end date (`last-call-date-time`), typically 14 days later. If this period results in necessary normative changes it will revert the HIP to Review.
 - __Council Review__ - Some HIPs will have to be approved by the Governing Council before getting a `Accepted` status'. This is usually the case for HIPs in the `Standards Track` type and `Core`, `Service` and `Mirror` categories, but can expand to other HIPs as well. The HIP editors will double-check if the `Yes` flag on `needs-council-approval` header field needs to be set. If HIP needs Governing Council approval, it will have to go through a 'Council Review' status and be reviewed at the next Technical Committee meeting of the Governing Council.
@@ -224,6 +225,7 @@ Each HIP must begin with a header preamble in a table format. The headers must a
 - title: HIP title
 - author: a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s).
 - working-group\*: a list of the technical and business stakeholders' name(s) and/or username(s), or name(s) and email(s).
+- implementer: person or group of people willing to implement the work
 - type: Standards Track | Informational | Process
 - category\*: Core | Service | API | Mirror | Application
 - needs-council-approval: Yes | No


### PR DESCRIPTION
This PR introduces a new status called `Stagnant` and header property `implementer` and outlines what to do with hips that are gathering dust. If a hip doesn't get enough community support and an implementer who is willing to do the work then after four weeks the hip gets a `Stagnant` status. After 6 months in `Stagnant` status, hips are rejected

Signed-off-by: Michael Garber <michael.garber@swirldslabs.com>
