### PR TITLE
Github Actions workflow to update discord on hip status change

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,34 @@
+name: Check for status change
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  StatusChangeCheck:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check status
+        id: status
+        continue-on-error: true
+        run:  echo ::set-output name=hipstatus::$(git diff HEAD^ HEAD -G'status:' | egrep "^\+status:" >> status && cut -d ":" -f2 status && rm -f status)
+      
+      - name: Get HIP name
+        if: steps.status.outcome == 'success'
+        id: hip_name
+        continue-on-error: true
+        run:  echo ::set-output name=hipname::$(basename -- $(git diff --name-only HEAD HEAD~1 | grep .md) .md)
+
+      - name: Discord notification
+        if: steps.status.outcome == 'success'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: '${{ steps.hip_name.outputs.hipname }} moved into ${{ steps.status.outputs.hipstatus }} status https://hips.hedera.com/hip/${{ steps.hip_name.outputs.hipname }}'

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,3 @@ _site/
 /.bundle/
 /vendor/bundle
 .idea
-
-## Workflows
-/.github/workflows

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ _site/
 /.bundle/
 /vendor/bundle
 .idea
+
+## Workflows
+/.github/workflows


### PR DESCRIPTION
In an effort to encourage community engagement for our hips, this PR introduces a GitHub Actions workflow that creates a discord post in the #hips channel every time the status of a hip changes

<img width="815" alt="image" src="https://user-images.githubusercontent.com/101222532/180073958-b1b21fc0-0e30-4744-af46-2f6bb90580c0.png">
<img width="716" alt="image" src="https://user-images.githubusercontent.com/101222532/180074833-4bee79c0-362e-4c7e-addb-1819d3e30383.png">

