### PR TITLE
Update hip-260 status and superseded-by

### DIFF
--- a/HIP/hip-260.md
+++ b/HIP/hip-260.md
@@ -5,12 +5,13 @@ author: Danno Ferrin <danno.ferrin@hedera.com>
 type: Standards Track 
 category: Service
 needs-council-approval: Yes
-status: Accepted
+status: Replaced
 last-call-date-time: 2021-12-21T07:00:00Z
 created: 2021-12-02
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/262
-updated: 2021-12-07, 2021-12-14
+updated: 2021-12-07, 2021-12-14, 2022-08-15
 requires: 206
+superseded-by: 513
 ---
 
 ## Abstract

--- a/HIP/hip-260.md
+++ b/HIP/hip-260.md
@@ -1,8 +1,8 @@
 ---
-hip: 260 
-title: Smart Contract Traceability 
+hip: 260
+title: Smart Contract Traceability
 author: Danno Ferrin <danno.ferrin@hedera.com>
-type: Standards Track 
+type: Standards Track
 category: Service
 needs-council-approval: Yes
 status: Replaced


### PR DESCRIPTION
This PR updates hip-260 to be in alignment with the information outlined in hip-513:
>This HIP overrides [HIP-260](https://hips.hedera.com/HIP/hip-260.html) by moving traceability info from ContractFunctionResult to sidecar ([HIP-435](https://hips.hedera.com/HIP/hip-435.html)).

Signed-off-by: Michael Garber <michael.garber@swirldslabs.com>