### PR TITLE
Add instructions for ruby bundler in readme for local build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ Each HIP should only be one single key proposal and/or idea. The idea should be 
 4. Reevaluate your proposal to ensure sure the idea is applicable to the entire community and not just to one particular author, application, project, or protocol.
 
 ## Local Jekyll Site
+Prereq - make sure you have bundler for Ruby
 
 You can run a local version of the HIPs dashboard site:
 
 ```shell
+bundle install
 jekyll serve --livereload
 ```
 


### PR DESCRIPTION
Our readme is missing the install step of the local build instruction so this pr adds that.
Signed-off-by: Michael Garber <michael.garber@swirldslabs.com>