### PR TITLE
Add step in workflow to delete branch on merge

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -37,7 +37,12 @@ jobs:
                 gh workflow run send-email.yml -f "filename=$(basename ${arrayOfFiles[$i]} .md)" -f "status=Last Call"
               fi
             done
-
+            
+      - name: Delete branch
+        if: github.event.pull_request.head.repo.url == github.event.pull_request.base.repo.url
+        uses: SvanBoxel/delete-merged-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         
             
 


### PR DESCRIPTION
We are turning off the setting that autodeletes branches when they merge into master because we have a workflow that depends on the branch history after merge and the branch was getting deleted before the workflow was done. This PR adds a step in the notifications workflow that deletes the branch after the workflow is done.

Signed-off-by: Michael Garber <michael.garber@swirldslabs.com>