### PR TITLE
Hip 412 reference implementation

### DIFF
--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -67,7 +67,7 @@ Below is the human-readable schema, presented to maximize clarity. This document
 		},
 		… multiple …
 	],
-	"format": "format designation",
+	"format": "format designation - OPTIONAL",
 	"properties": {
 		// arbitrary json objects that cover the overarching properties of the token
 	},
@@ -86,7 +86,7 @@ Below is the human-readable schema, presented to maximize clarity. This document
 
 The `type` field is **required** and must display the mime type of the `image` such as "image/jpeg" or "image/png".
 
-`creator`, `creator DID`, `attributes`, `files`, `properties` and `localization` are optional and do not need to be included in the metadata.
+`creator`, `creator DID`, `format`, `attributes`, `files`, `properties` and `localization` are optional and do not need to be included in the metadata.
 
 The `checksum` is also optional but recommended when using a file hosted at a centralized server. It allows NFT tooling to verify the image integrity, same for `files` where this property also applies.
 
@@ -171,8 +171,6 @@ For the optional fields of attributes and properties, as well as any additional 
 This allows NFT creators, communities and platforms to explicitly define the schema that they are using, which simplifies implementation for other projects hoping to use the same definition.
 
 To reduce errors, "format" should be lower-case. For robustness, galleries and viewers should interpret format in a case-insensitive way to account for mistakes.
-
-For the purposes of this base metadata schema we also define `"format": "none"`, which is a catch-all that explicitly states that the NFT only follows the base fields of the schema but may define any number of additional fields.
 
 The recommended schema for Hedera NFTs is `HIP412@1.0.0`. You can find the reference implementation for the `HIP412@1.0.0` standard here: https://gist.github.com/michielmulders/571c496789ede04c9074817cee834246. This standard can evolve. Semantic versioning has been applied to the standard. The first version of the standard is represented by `HIP412@1.0.0`.
 
@@ -354,7 +352,7 @@ _Allowed types: string, integer, number, boolean_
 _Allowed types: string, integer, number_
 
 
-### Example Schema: none
+### Example Schema: Image NFT with no format defined
 
 This is an example of a basic metadata as described by this schema. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. Note that all the fields in properties are arbitrary.
 ```json
@@ -364,7 +362,6 @@ This is an example of a basic metadata as described by this schema. Format "none
 	"description": "This is an example NFT metadata",
 	"image": "ipfs://bafkreibwci24bt2xtqi23g35gfx63wj555u77lwl2t55ajbfjqomgefxce",
 	"type": "image/png",
-	"format": "none",
 	"properties": {
 		"license": "MIT-0",
 		"collection": "Generic Collection Name",
@@ -372,7 +369,7 @@ This is an example of a basic metadata as described by this schema. Format "none
 	}
 }
 ```
-### Example Schema: none (video NFT)
+### Example Schema: Video NFT with no format defined
 
 This is an example of a basic metadata as described by this schema. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. Note that this NFT does not include an image, nor does it define any arbitrary properties.
 
@@ -383,7 +380,6 @@ This is an example of a basic metadata as described by this schema. Format "none
 	"description": "This is an example NFT metadata",
 	"image": "ipfs://bafkreibwci24bt2xtqi23g35gfx63wj555u77lwl2t55ajbfjqomgefxce",
 	"type": "image/jpg",
-	"format": "none",
 	"files": [
 		{
 			"uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
@@ -402,9 +398,9 @@ This is an example of a basic metadata as described by this schema. Format "none
 }
 ```
 
-### Example Schema: none (localized multi-file NFT - video and PDF)
+### Example Schema: localized multi-file NFT (video and PDF) with no format defined
 
-An example similar to the above one. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. The NFT does not contain a thumbnail. The localization attributes would point to localized metadata for the NFT specification
+An example similar to the above one. This metadata schema does not adhere to any specific sub-schema. The NFT does not contain a thumbnail. The localization attributes would point to localized metadata for the NFT specification
 ```json
 {
 	"name": "Example NFT",
@@ -414,7 +410,6 @@ An example similar to the above one. Format "none" is used to indicate that this
 	"image": "https://myserver.com/preview-image-001.png",
 	"checksum": "9defbb6402d4bf39f2ea580099c73194647b24a659b6f6b778e3dd71755b8862",
 	"type": "image/png",
-	"format": "none",
 	"files": [
 		{
 			"uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -53,15 +53,15 @@ Below is the human-readable schema, presented to maximize clarity. This document
     "creator": "artist",
     "creatorDID": "DID URI",
     "description": "human readable description of the asset - RECOMMENDED",
-    "image": "cid or path to the NFT's image file, or for non-image NFTs, optional preview image - RECOMMENDED",
+    "image": "cid or path to the NFT's image file, or for non-image NFTs, optional preview image - REQUIRED",
     "checksum": "SHA-256 digest of the file pointed by the image field - OPTIONAL",
-    "type": "mime type - ie image/jpeg - CONDITIONALLY OPTIONAL",
+    "type": "mime type - ie image/jpeg - REQUIRED",
     "files": [ // object array that contains uri, type and metadata
         {
-            "uri": "uri to file",
+            "uri": "uri to file - REQUIRED",
             "checksum": "cryptographic SHA-256 hash of the representation of the resource the author expects to load - OPTIONAL",
             "is_default_file": "(Type: boolean) indicates if the file is the main file for this NFT - OPTIONAL",
-            "type": "mime type",
+            "type": "mime type - REQUIRED",
             "metadata": "metadata object - OPTIONAL",
             "metadata_uri": "uri to metadata - OPTIONAL"
         },
@@ -80,9 +80,9 @@ Below is the human-readable schema, presented to maximize clarity. This document
 
 ### Required, Optional and Conditionally Optional fields:
 
-`name`, `description`, and `image` are the three basic fields in ERC721 NFT standards. A `name` is **required** for all NFT’s. The `description` and `image` fields are optional, but recommended to enable apps to display them better.
+`name`, `description`, and `image` are the three basic fields in ERC721 NFT standards. `name` and `image` are **required** for all NFT’s as part of this HIP. The `description` field is optional, but recommended to enable apps to display them better.
 
-The `type` field is listed as *Conditionally Optional*. If `image` is defined, then `type` **must** be defined as well.
+The `type` field is **required** and must display the mime type of the `image` such as "image/jpeg" or "image/png".
 
 `creator`, `creator DID`, `attributes`, `files`, `properties` and `localization` are optional and do not need to be included in the metadata.
 
@@ -112,13 +112,13 @@ https://w3c.github.io/did-core/
 
 A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive. See **[uri formatting]** section for more details.
 
-The `image` field is required. It can both serve as a preview image or the full resolution image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Creators are recommended to point to a thumbnail in the `image` field, and put the high resolution imagein the `files` with the `is_default_file` boolean set to indicate that this file represents the default image for the NFT.
+The `image` field is required. It can both serve as a preview image or the full resolution image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Creators are recommended to point to a thumbnail in the `image` field, and put the high resolution image in the `files` array with the `is_default_file` boolean set to indicate that this file represents the default image for the NFT.
 
 "image" is a standard field across other chains and is required for this standard. There was discussion to change this to a more generic name such as ‘file’ or ‘uri’, however this would break cross-chain compatibility of this standard.
 
 #### checksum
 
-The `checksum` property represents a SHA-256 digest of the file pointed by the `image` property. The `checksum` property that contains a cryptographic hash of the representation of the resource the author expects to load. 
+The `checksum` property represents a SHA-256 digest of the file pointed by the `image` property. The `checksum` property contains a cryptographic hash of the representation of the resource the author expects to load. 
 
 For instance, an author may wish to load some image from a shared server. Specifying that the expected SHA-256 hash of https://example.com/image.jpeg is ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad means that the user agent can verify that the data it loads from that URL matches that expected hash before loading the NFT. This integrity verification significantly reduces the risk that an attacker can substitute malicious content.
 
@@ -139,9 +139,9 @@ Including the mime type allows applications to properly handle the file and grea
 "files" is an array of objects with the following format:
 ```json
 {
-    "uri": "uri to file",
+    "uri": "uri to file - REQUIRED",
     "checksum": "cryptographic hash of the representation of the resource the author expects to load - OPTIONAL",
-    "type": "mime type",
+    "type": "mime type - REQUIRED",
     "is_default_file": true,
     "metadata": "metadata object - OPTIONAL",
     "metadata_uri": "uri to metadata - OPTIONAL"
@@ -172,7 +172,7 @@ To reduce errors, "format" should be lower-case. For robustness, galleries and v
 
 For the purposes of this base metadata schema we also define `"format": "none"`, which is a catch-all that explicitly states that the NFT only follows the base fields of the schema but may define any number of additional fields.
 
-Other possible values for this schema are: `HIP412@1.0.0` and `opensea`. When you leave the `format` field blank, it is assumed you are using the [`HIP412@1.0.0` standard](https://gist.github.com/michielmulders/571c496789ede04c9074817cee834246). This standard can evolve. Therefore, semantic versioning has been applied to the standard. The first version of the standard is represented by `HIP412@1.0.0`.
+The recommended schema for Hedera NFTs is `HIP412@1.0.0`. You can find the reference implementation for the `HIP412@1.0.0` standard here: https://gist.github.com/michielmulders/571c496789ede04c9074817cee834246. This standard can evolve. Semantic versioning has been applied to the standard. The first version of the standard is represented by `HIP412@1.0.0`.
 
 #### properties
 
@@ -233,7 +233,7 @@ Note that mime types for directories are not uniformly defined. Some IPFS CIDs p
 
 ## Reference Implementation
 
-### Example Schema: Collectibe Hedera NFTs (format: "HIP412@1.0.0")
+### Default Schema: Collectibe Hedera NFTs (format: "HIP412@1.0.0")
 
 This is a **recommended reference implementation for collectible Hedera NFTs**. The `HIP412` standard has been designed to be used by all NFT tooling (wallets, explorers) and be mostly compatible with other existing standards. 
 
@@ -302,20 +302,11 @@ The standard also allows for localization. Each locale links to another metadata
 			"value": 732844800
 		}
 	],
-	"localization": [
-		{
-			"locale": "en",
-			"is_default_locale": true
-		},
-		{
-			"locale": "es",
-			"uri": "ipfs://keiyidooajiaefklankfldanmfoieoakddqtyty"
-		},
-		{
-			"locale": "jp",
-			"uri": "ipfs://yidooajiaefiakfldanm12554woakoakga4sfda"
-		}
-	]
+	"localization": {
+		"uri": "ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT/{locale}.json",
+		"default": "en",
+		"locales": ["es", "fr"]
+	}
 }
 ```
 
@@ -355,27 +346,30 @@ _Allowed types: string, integer, number, boolean_
 
 _Allowed types: string, integer, number_
 
-#### localization.locale
+#### localization.locales
 
-(Required) A two-letter language code identifying the file's language. No need to further define subregion locales such as `en-GB` to keep things simple.
+(Required) An array containing two-letter language codes identifying the possible languages for this NFT specification. No need to further define subregion locales such as `en-GB` to keep things simple.
 
 _Type: string (two-letter language code according to [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))_
 
 
-#### localization.is_default_locale
+#### localization.default
 
-(Conditionally Required) Indicates the primary language for this NFT. When multiple locales are listed, make sure to add this property to set the default locale for this metadata file. When `is_default_locale` is set, the `uri` property should not be defined for this localization object.
+(Required) Indicates the primary language for this NFT.
 
-_Type: boolean (false/true)_
+_Type: string (two-letter language code according to [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))_
 
 
 #### localization.uri
 
-(Conditionally Required) CID or path to the localized NFT's metadata file. It's recommended to host your file on [IPFS](https://ipfs.io/) and use a service like [Pinata](https://pinata.cloud/) to easily pin your file. Your CID should look like this: `ipfs://<hash>`.
+(Required) CID or path to the localized NFT's metadata file. It's recommended to host your file on [IPFS](https://ipfs.io/) and use a service like [Pinata](https://pinata.cloud/) to easily pin your file. Your CID should look like this: `ipfs://<hash>`.
 
 Alternatively, you can use [Arweave](https://www.arweave.org/), receiving a similar CID that looks like this: `ar://<hash>`.
 
-When `is_default_locale` is set, don't define the `uri` property because it indicates the default language for this NFT's metadata.
+The format of the uri should look like this `<protocol>://<hash>/{locale}.json`. The `{locale}` part references to a locale in the `locales` array. For instance, if you define the following locales `locales: ["es", "fr"]`, you should upload the following files to IPFS (or Arweave):
+
+- "ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT/es.json"
+- "ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT/fr.json"
 
 
 ### Example Schema: none
@@ -396,9 +390,10 @@ This is an example of a basic metadata as described by this schema. Format "none
     }
 }
 ```
-### Example Schema: none, video
+### Example Schema: none (video NFT)
 
 This is an example of a basic metadata as described by this schema. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. Note that this NFT does not include an image, nor does it define any arbitrary properties.
+
 ```json
 {
     "name": "Example NFT",
@@ -425,7 +420,7 @@ This is an example of a basic metadata as described by this schema. Format "none
 }
 ```
 
-### Example Schema: none, video, multiple files, localization
+### Example Schema: none (localized multi-file NFT - video and PDF)
 
 An example similar to the above one. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. The NFT does not contain a thumbnail, but some of the sub-files define their own thumbnails and localizations. The localization attributes would point to localized metadata for each sub-file.
 ```json
@@ -489,6 +484,7 @@ The following is the formal definition of this schema using JSON Schema notation
 For more info see here: https://json-schema.org/
 ```json
 {
+	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Token Metadata",
 	"type": "object",
 	"properties": {

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -245,6 +245,8 @@ You can optionally define `attributes` to calculate rarity scores. We've added t
 
 The standard also allows for localization. Each locale links to another metadata file that contains the localized metadata and files. This allows for a clean metadata structure. Don't define another localization object for a localized metadata file to avoid infinite looping when parsing an NFT's metadata file.
 
+**A JSON schema can be found [here](https://gist.github.com/michielmulders/1565e7759d692b65fa8c38cfe15b010c).**
+
 ```json
 {
 	"name": "Example NFT 001",
@@ -340,11 +342,13 @@ Name of trait.
 
 (Required) Value for trait. To give an example, imagine an NFT with the `trait_type: mouth`. Possible values are `bubblegum`, `smiling`, `braces`, or `trumpet`. 
 
-**Type:** Allowed types: string, integer, number, boolean
+**Allowed types:** string, integer, number, boolean
 
 #### attributes.max_value
 
 (Optional) Adding a `max_value` sets a ceiling for a numerical trait's possible values. **NFT tooling should default this value to the maximum value seen for a collection.** Only use this property if you want to set a different value than the maximum value seen in the collection. Make sure the `max_value` is equal to or higher than the maximum value seen for your collection.
+
+**Allowed types:** string, integer, number
 
 #### localization.locale
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -120,6 +120,14 @@ If one or more files are defined under "files", "image" is considered to be the 
 
 "image" is a standard field across other chains. There was discussion to change this to a more generic name such as ‘file’ or ‘uri’, however this would break cross-chain compatibility of this standard. Although image is defined as conditionally optional, ensure that it is defined in formats such as opensea where it is required.
 
+#### sha256_checksum
+
+SHA-256 digest of the file pointed by the `image` property. The `sha256_checksum` property that contains a cryptographic hash of the representation of the resource the author expects to load. 
+
+For instance, an author may wish to load some image from a shared server. Specifying that the expected SHA-256 hash of https://example.com/image.jpeg is ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad means that the user agent can verify that the data it loads from that URL matches that expected hash before loading the NFT. This integrity verification significantly reduces the risk that an attacker can substitute malicious content.
+
+References: https://w3c.github.io/webappsec-subresource-integrity/
+
 #### type
 
 Mime type of the image file. See **[mime formatting]** section for more details.
@@ -134,14 +142,20 @@ Including the mime type allows applications to properly handle the file and grea
 ```json
 {
     "uri": "uri to file",
+    "sha256_checksum": "cryptographic hash of the representation of the resource the author expects to load - OPTIONAL",
     "type": "mime type",
+    "is_default_file": true,
     "metadata": "metadata object - OPTIONAL",
     "metadata_uri": "uri to metadata - OPTIONAL"
 }
 ```
 "uri" is the uri to the file. See [URI Formatting]
 
+"sha256_checksum" is an optional cryptographic hash of the representation of the resource the author expects to load.
+
 "type" is required and is the mime-type of the file pointed to by the uri, see [Mime Formatting]
+
+"is_default_file" is required when multiple file objects are listed for the files array. It allows the user to define which file is the default file for the NFT. If a single file is listed, this file becomes the default file. Therefore, the field is optional.
 
 “metadata” is optional. This is a nested metadata object for the file, which follows the same metadata format as the root metadata. Files can be nested indefinitely in this way, but processed with the same metadata code.
 
@@ -150,8 +164,6 @@ Including the mime type allows applications to properly handle the file and grea
 **To avoid conflicts, if "metadata" is defined then "metadata_uri" should be ignored.**
 
 An NFT creator has the option of using either "metadata" or "metadata_uri". Metadata should be considered the default behaviour as it minimizes the number of calls that need to be made. Metadata_uri should be used in specific situations where defining the metadata object within the base metadata file is inadequate.
-
-The opensea format defines "files" under the "properties" field. This standard places files in the root of the metadata in order to accommodate non-image NFT’s. It is recommended for NFT’s with the "opensea" format that they follow the opensea standard of placing files under the properties field, for cross-compatibility with other NFT’s, and not define a "files" field in the metadata root. The idea comes from the Solana NFT Standard from Metaplex: https://docs.metaplex.com/token-metadata/specification
 
 #### format
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -505,11 +505,11 @@ For more info see here: https://json-schema.org/
 				},
 				"metadata": {
 					"type": "object",
-					"description": "Represents a nested metadata object for the file."
+					"description": "Represents a nested metadata object for the file, which follows the same metadata format as the root metadata. Files can be nested indefinitely in this way, but processed with the same metadata code."
 				},
 				"metadata_uri": {
 					"type": "string",
-					"description": "uri pointing to the metadata for this file"
+					"description": "A URI pointing to a metadata resource, which follows the same metadata format as the root metadata. Files can be nested indefinitely in this way, but processed with the same metadata code."
 				}
 			},
 			"required": [

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -84,8 +84,6 @@ Below is the human-readable schema, presented to maximize clarity. This document
 
 The `type` field is listed as *Conditionally Optional*. If `image` is defined, then `type` **must** be defined as well.
 
-`is_default_file` is listed as *Conditionally Optional*. If the `files` array contains multiple file objects, `is_default_file` **must** be defined as well.
-
 `creator`, `creator DID`, `attributes`, `files`, `properties` and `localization` are optional and do not need to be included in the metadata.
 
 The `sha256_checksum` is also optional but recommended when using a file hosted at a centralized server. It allows NFT tooling to verify the image integrity, same for `files` where this property also applies.
@@ -114,11 +112,9 @@ https://w3c.github.io/did-core/
 
 Points to the uri of the image file. See **[uri formatting]** section for more details.
 
-If one or more files are defined under "files", "image" is considered to be the thumbnail that represents the array of files. The term ‘thumbnail’ does not imply that the image size is reduced; "image" should always be the full resolution image. 
+The `image` field is optional but recommended. It can both serve as a preview image or the default image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Use the `is_default_file` in your `files` array to mark a file as the one you would prefer to have displayed by default if the NFT tooling supports it. In this case, the `image` field serves as a preview image or 'thumbnail'.
 
-"image" was originally listed as ‘required’, however HashAxis noted that in the case of file NFTs, creating both image and file would require two files to pin instead of one. At the scale of millions, this doubling of the number of pinned images is significantly impactful to the cost of hosting the files. For files that can have their thumbnails generated programmatically, an image is not required. Because of this, the "image" field was changed to Optional.
-
-"image" is a standard field across other chains. There was discussion to change this to a more generic name such as ‘file’ or ‘uri’, however this would break cross-chain compatibility of this standard. Although image is defined as optional, ensure that it is defined in formats such as opensea where it is required.
+"image" is a standard field across other chains and is required for this standard. There was discussion to change this to a more generic name such as ‘file’ or ‘uri’, however this would break cross-chain compatibility of this standard.
 
 #### sha256_checksum
 
@@ -241,7 +237,7 @@ This is a **recommended reference implementation for collectible Hedera NFTs**. 
 
 Here's an example of a full implementation of the metadata schema described in this `HIP412` specification for an image-based NFT. We are setting the image field to a URI and including the `sha256_checksum` field which represents a hash of the provided image. 
 
-The `files` array contains the main image hosted on IPFS, also including an optional checksum for validation purposes. The `image` field serves as a preview image for NFT tooling where a programatically generated image doesn't work or you would like to have a different preview image. Therefore, the `image` field remains optional.
+The `files` array contains file objects (e.g. multi-file NFTs), also including an optional checksum for validation purposes. The `image` field can both serve as a preview image or the default image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Use the `is_default_file` in your `files` array to mark a file as the one you would prefer to have displayed by default if the NFT tooling supports it. In this case, the `image` field serves as a preview image. **The standard recommends using the `image` field as a preview image by marking another file in the `files` array as default.**
 
 Further, no additional properties are defined on the JSON object on root level. Any additional properties you want to define should go into the `properties` object.
 
@@ -322,15 +318,17 @@ The standard also allows for localization. Each locale links to another metadata
 
 Here's a clarification for the most important fields for the `HIP412` format.
 
-#### files
+#### image
 
-(Required) `files` array holds one or many files. Because the optional `image` property can be used as a preview image, the `files` array should at least hold one `file` object that represents the NFT. 
+(Required) The `image` field can both serve as a preview image or the default image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Use the `is_default_file` in your `files` array to mark a file as the one you would prefer to have displayed by default if the NFT tooling supports it. In this case, the `image` field serves as a preview image or 'thumbnail'. **The standard recommends using the `image` field as a preview image by marking another file in the `files` array as default.**
+
 
 #### attributes.trait_type
 
 (Required) Name of trait.
 
-### attributes.display_type
+
+#### attributes.display_type
 
 (Optional) Indicates how the trait value should be displayed. Possible display types (but other types are allowed):
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -71,9 +71,11 @@ Below is the human-readable schema, presented to maximize clarity. This document
 	"properties": {
 		// arbitrary json objects that cover the overarching properties of the token
 	},
-	"localization": [ 
-		// optional array of localization objects
-	]
+	"localization": {
+		"uri": "uri to file, using format: <protocol>://<hash>/{locale}.json - REQUIRED",
+		"default": "two-letter language code identifying default language for NFT specification - REQUIRED",
+		"locales": "array containing two-letter language codes identifying other localized metadata specifications for this NFT - REQUIRED"
+	}
 	// additional fields defined per the format
 }
 ```
@@ -187,17 +189,22 @@ Best Practice Recommendation: **It is strongly recommended that information such
 
 #### localization
 
-Localization is an optional array of localization objects, which allow tokens/applications to present data uniformity across all languages.
+Localization is an optional object that points to language-specific metadata files for this NFT. 
 
-Each localization attribute is a sub-object with two attributes: uri and locale.
+locales - (Required) An array containing two-letter language codes identifying the possible languages for this NFT specification. No need to further define subregion locales such as `en-GB` to keep things simple.
 
-uri - A URI to localized metadata in the specified locale. An application utilizing this metadata would discard the original metadata and use the localized metadata. It is the responsibility of the token creator to ensure that all non-localized fields and information is duplicated across the localized and base metadata.
+_Type: string (two-letter language code according to [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))_
 
-is_default_locale - Indicates the primary language for this NFT. When multiple locales are listed, make sure to add this property to set the default locale for this metadata file. When `is_default_locale` is set, the `uri` property should not be defined for this localization object because the current metadata represents this locale.
+default - (Required) Indicates the primary language for this NFT metadata specification. This locale should not be repeated in the `locales` array.
 
-locale - Specified two-letter language code, ie. en , fr , es per [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+_Type: string (two-letter language code according to [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))_
 
-If localization is defined, an application may choose to use the localized metadata instead.
+uri - (Required) CID or path to the localized NFT's metadata file. It's recommended to host your file on [IPFS](https://ipfs.io/) and use a service like [Pinata](https://pinata.cloud/) to easily pin your file. Your CID should look like this: `ipfs://<hash>`.
+
+Alternatively, you can use [Arweave](https://www.arweave.org/), receiving a similar CID that looks like this: `ar://<hash>`.
+
+The format of the uri should look like this `<protocol>://<hash>/{locale}.json`. The `{locale}` part references to a locale in the `locales` array. For instance, if you define the following locales `locales: ["es", "fr"]`, you should upload the following files to IPFS (or Arweave): "ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT/es.json" and "ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT/fr.json".
+
 
 ### Formatting Notes
 
@@ -346,31 +353,6 @@ _Allowed types: string, integer, number, boolean_
 
 _Allowed types: string, integer, number_
 
-#### localization.locales
-
-(Required) An array containing two-letter language codes identifying the possible languages for this NFT specification. No need to further define subregion locales such as `en-GB` to keep things simple.
-
-_Type: string (two-letter language code according to [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))_
-
-
-#### localization.default
-
-(Required) Indicates the primary language for this NFT metadata specification. This locale should not be repeated in the `locales` array.
-
-_Type: string (two-letter language code according to [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))_
-
-
-#### localization.uri
-
-(Required) CID or path to the localized NFT's metadata file. It's recommended to host your file on [IPFS](https://ipfs.io/) and use a service like [Pinata](https://pinata.cloud/) to easily pin your file. Your CID should look like this: `ipfs://<hash>`.
-
-Alternatively, you can use [Arweave](https://www.arweave.org/), receiving a similar CID that looks like this: `ar://<hash>`.
-
-The format of the uri should look like this `<protocol>://<hash>/{locale}.json`. The `{locale}` part references to a locale in the `locales` array. For instance, if you define the following locales `locales: ["es", "fr"]`, you should upload the following files to IPFS (or Arweave):
-
-- "ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT/es.json"
-- "ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT/fr.json"
-
 
 ### Example Schema: none
 
@@ -422,7 +404,7 @@ This is an example of a basic metadata as described by this schema. Format "none
 
 ### Example Schema: none (localized multi-file NFT - video and PDF)
 
-An example similar to the above one. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. The NFT does not contain a thumbnail, but some of the sub-files define their own thumbnails and localizations. The localization attributes would point to localized metadata for each sub-file.
+An example similar to the above one. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. The NFT does not contain a thumbnail. The localization attributes would point to localized metadata for the NFT specification
 ```json
 {
 	"name": "Example NFT",
@@ -440,17 +422,7 @@ An example similar to the above one. Format "none" is used to indicate that this
 			"is_default_file": true,
 			"metadata": {
 				"name": "Example Video"
-			},
-			"localization": [
-				{
-					"uri": "ipfs://dfa3tjaklfjoiaefklankfdf3d32zafga3tfD",
-					"locale": "es"
-				},
-				{
-					"uri": "ipfs://dija9jaklfjoiaefklankf13fsef36aga4fda",
-					"locale": "jp"
-				}
-			]
+			}
 		},
 		{
 			"uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
@@ -463,16 +435,11 @@ An example similar to the above one. Format "none" is used to indicate that this
 			}
 		}
 	],
-	"localization": [
-		{
-			"uri": "ipfs://bawlkjaklfjoiaefklankflda132zafga3tfa",
-			"locale": "es"
-		},
-		{
-			"uri": "ipfs://bawlkjaklfjoiaefklankf12554wa6aga4fda",
-			"locale": "jp"
-		}
-	]
+	"localization": {
+		"uri": "ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT/{locale}.json",
+		"default": "en",
+		"locales": ["es", "fr"]
+	}
 }
 ```
 
@@ -566,27 +533,27 @@ For more info see here: https://json-schema.org/
 			"description": "Optional. Arbitrary properties. Values may be strings, numbers, booleans, objects or arrays."
 		},
 		"localization": {
-			"type": "array",
-			"description": "Array of localized metadata.",
-			"items": {
+			"type": "object",
+			"required": ["uri", "default", "locales"],
+			"properties": {
 				"uri": {
 					"type": "string",
 					"format": "uri",
-					"description": "A URI pointing to the localized metadata json file for this locale."
+					"description": "The URI pattern to fetch localized data from. This URI should contain the substring `{locale}` which will be replaced with the appropriate two-letter langauge code value before sending the request. Format: <protocol>://<hash>/{locale}.json"
 				},
-				"is_default_locale": {
-					"type": "boolean",
-					"description": "Indicates if the set locale is the default locale for this metadata file."
-				},
-				"locale": {
+				"default": {
 					"type": "string",
-					"description": "A two-letter locale."
+					"description": "Sets the two-letter language code that represents the default locale for this metadata file."
+				},
+				"locales": {
+					"type": "array",
+					"description": "The list of locales for which data is available.",
+					"items": {
+						"type": "string",
+					}
 				}
-			},
-			"required": [
-				"locale"
-			],
-		},
+			}
+		}
 	},
 	"required": [ "name", "image", "type" ]
 }

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -112,7 +112,7 @@ https://w3c.github.io/did-core/
 
 A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive. See **[uri formatting]** section for more details.
 
-The `image` field is required. It can both serve as a preview image or the default image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Use the `is_default_file` in your `files` array to mark a file as the one you would prefer to have displayed by default if the NFT tooling supports it. In this case, the `image` field serves as a preview image or 'thumbnail'.
+The `image` field is required. It can both serve as a preview image or the full resolution image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Creators are recommended to point to a thumbnail in the `image` field, and put the high resolution imagein the `files` with the `is_default_file` boolean set to indicate that this file represents the default image for the NFT.
 
 "image" is a standard field across other chains and is required for this standard. There was discussion to change this to a more generic name such as ‘file’ or ‘uri’, however this would break cross-chain compatibility of this standard.
 
@@ -153,7 +153,7 @@ Including the mime type allows applications to properly handle the file and grea
 
 "type" is required and is the mime-type of the file pointed to by the uri, see [Mime Formatting]
 
-"is_default_file" is optional and allows the user to define which file is the default file for the NFT. It's useful when you want to define another file as the default file your NFT than the one listed in the `image` field. It can also be used for indicating the main file for a multi-file NFT. 
+"is_default_file" is optional and allows the user to define which file is the default high resolution file for the NFT. It's useful when you want to define another file as the default high resolution file your NFT than the one listed in the `image` field (recommended). It can also to indicate the main file for a multi-file NFT. 
 
 “metadata” is optional. This is a nested metadata object for the file, which follows the same metadata format as the root metadata. Files can be nested indefinitely in this way, but processed with the same metadata code.
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -412,7 +412,7 @@ This is an example of a basic metadata as described by this schema. Format "none
                 "image": "ipfs://bakcjlajeioajflakdjfneafoaeinovandklf",
                 "format": "none",
                 "properties": {
-                    "additional_description": "the image in this nested metadata is the video thumbnail."
+                    "additional_description": "The image in this nested metadata is the video thumbnail."
                 }
             }
         }

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -522,14 +522,14 @@ The following is the formal definition of this schema using JSON Schema notation
 For more info see here: https://json-schema.org/
 ```json
 {
-    "title": "Token Metadata",
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string",
-            "description": "Identifies the asset to which this token represents."
-        },
-        "creator": {
+	"title": "Token Metadata",
+	"type": "object",
+	"properties": {
+		"name": {
+			"type": "string",
+			"description": "Identifies the asset to which this token represents."
+		},
+		"creator": {
 			"type": "string",
 			"description": "Identifies the artist name(s)."
 		},
@@ -538,90 +538,90 @@ For more info see here: https://json-schema.org/
 			"format": "uri",
 			"description": "Points to a decentralized identifier to identify the creator.",
 		},
-        "description": {
-            "type": "string",
-            "description": "Describes the asset to which this token represents."
-        },
-        "image": {
-            "type": "string",
-            "format": "uri",
-            "description": "A URI pointing to a resource. Conditionally Optional."
-        },
-        "sha256_checksum": {
+		"description": {
+			"type": "string",
+			"description": "Describes the asset to which this token represents."
+		},
+		"image": {
+			"type": "string",
+			"format": "uri",
+			"description": "A URI pointing to a resource. Conditionally Optional."
+		},
+		"sha256_checksum": {
 			"type": "string",
 			"description": "Cryptographic hash of the representation of the 'image' resource."
 		},
-        "type": {
-            "type": "string",
-            "description": "Mime type of image. Required if image is defined."
-        },
-        "files": {
-            "type": "array",
-            "contains": {
+		"type": {
+			"type": "string",
+			"description": "Mime type of image. Required if image is defined."
+		},
+		"files": {
+			"type": "array",
+			"contains": {
 				"type": "object"
 			},
-            "description": "Array of files.",
-            "items": {
-                "uri": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "A URI pointing to a resource."
-                },
-                "sha256_checksum": {
-                    "type": "string",
-                    "description": "Cryptographic hash of the representation of the 'uri' resource."
-                },
-                "type": {
-                    "type": "string",
-                    "description": "Mime type of the resource."
-                },
-                "is_default_file": {
-                    "type": "boolean",
-                    "description": "Indicates if this file object is the main file representing the NFT."
-                },
-                "metadata": {
-                    "type": "object",
-                    "description": "Represents a nested metadata object for the file."
-                },
-                "metadata_uri": {
-                    "type": "string",
-                    "description": "uri pointing to the metadata for this file"
-                }
-            },
-            "required": [
-                "uri",
-                "type"
-            ],
-            "additionalProperties": false
-        },
-        "format": {
-            "type": "string",
-            "description": "Name of the format used by the NFT."
-        },
-        "properties": {
-            "type": "object",
-            "description": "Optional. Arbitrary properties. Values may be strings, numbers, booleans, objects or arrays."
-        },
-        "localization": {
-            "type": "array",
-            "description": "Array of localized metadata.",
-            "items": {
-                "uri": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "A URI pointing to the localized metadata json file for this locale."
-                },
-                "locale": {
-                    "type": "string",
-                    "description": "A two-letter locale."
-                }
-            },
-            "required": [
-                "locale"
-            ],
-        },            
-    },
-    "required": [ "name" ]
+			"description": "Array of files.",
+			"items": {
+				"uri": {
+					"type": "string",
+					"format": "uri",
+					"description": "A URI pointing to a resource."
+				},
+				"sha256_checksum": {
+					"type": "string",
+					"description": "Cryptographic hash of the representation of the 'uri' resource."
+				},
+				"type": {
+					"type": "string",
+					"description": "Mime type of the resource."
+				},
+				"is_default_file": {
+					"type": "boolean",
+					"description": "Indicates if this file object is the main file representing the NFT."
+				},
+				"metadata": {
+					"type": "object",
+					"description": "Represents a nested metadata object for the file."
+				},
+				"metadata_uri": {
+					"type": "string",
+					"description": "uri pointing to the metadata for this file"
+				}
+			},
+			"required": [
+				"uri",
+				"type"
+			],
+			"additionalProperties": false
+		},
+		"format": {
+			"type": "string",
+			"description": "Name of the format used by the NFT."
+		},
+		"properties": {
+			"type": "object",
+			"description": "Optional. Arbitrary properties. Values may be strings, numbers, booleans, objects or arrays."
+		},
+		"localization": {
+			"type": "array",
+			"description": "Array of localized metadata.",
+			"items": {
+				"uri": {
+					"type": "string",
+					"format": "uri",
+					"description": "A URI pointing to the localized metadata json file for this locale."
+				},
+				"locale": {
+					"type": "string",
+					"description": "A two-letter locale."
+				}
+			},
+			"required": [
+				"locale"
+			],
+		},
+	},
+	"required": [ "name" ]
 }
 ```
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -53,7 +53,7 @@ Below is the human-readable schema, presented to maximize clarity. This document
 	"creator": "artist",
 	"creatorDID": "DID URI",
 	"description": "human readable description of the asset - RECOMMENDED",
-	"image": "cid or path to the NFT's image file, or for non-image NFTs, optional preview image - REQUIRED",
+	"image": "cid or path to the NFT's image file, or for non-image NFTs, a preview image for display in wallets - REQUIRED",
 	"checksum": "SHA-256 digest of the file pointed by the image field - OPTIONAL",
 	"type": "mime type - ie image/jpeg - REQUIRED",
 	"files": [ // object array that contains uri, type and metadata

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -110,7 +110,7 @@ https://w3c.github.io/did-core/
 
 #### image
 
-Points to the uri of the image file. See **[uri formatting]** section for more details.
+A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive. See **[uri formatting]** section for more details.
 
 The `image` field is optional but recommended. It can both serve as a preview image or the default image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Use the `is_default_file` in your `files` array to mark a file as the one you would prefer to have displayed by default if the NFT tooling supports it. In this case, the `image` field serves as a preview image or 'thumbnail'.
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -54,10 +54,13 @@ Below is the human-readable schema, presented to maximize clarity. This document
     "creatorDID": "DID URI",
     "description": "human readable description of the asset - RECOMMENDED",
     "image": "cid or path to the NFT's image file, or for non-image NFTs, optional preview image - RECOMMENDED",
-    "type": "mime type - ie image/jpeg - CONDITIONALLY OPTIONAL ",
+    "sha256_checksum": "SHA-256 digest of the file pointed by the image field - OPTIONAL",
+    "type": "mime type - ie image/jpeg - CONDITIONALLY OPTIONAL",
     "files": [ // object array that contains uri, type and metadata
         {
             "uri": "uri to file",
+            "sha256_checksum": "cryptographic hash of the representation of the resource the author expects to load - OPTIONAL",
+            "is_default_file": "(Type: boolean) indicates if the file is the main file for this NFT - CONDITIONALLY OPTIONAL",
             "type": "mime type",
             "metadata": "metadata object - OPTIONAL",
             "metadata_uri": "uri to metadata - OPTIONAL"
@@ -66,21 +69,26 @@ Below is the human-readable schema, presented to maximize clarity. This document
     ],
     "format": "format designation",
     "properties": {
-    // arbitrary json objects that cover the overarching properties of the token
+        // arbitrary json objects that cover the overarching properties of the token
     },
-    "localization": { 
-    // optional array of localization objects
-    }
+    "localization": [ 
+        // optional array of localization objects
+    ]
     // additional fields defined per the format
 }
 ```
+
 ### Required, Optional and Conditionally Optional fields:
 
 Name, description and image are the three basic fields in ERC721 NFT standards. Name is **required** for all NFT’s. Description and image are optional, but recommended to enable apps to display them better.
 
 Type is listed as *Conditionally Optional*. If Image is defined, then type **must** be defined as well.
 
+`is_default_file` is listed as *Conditionally Optional*. If the Files array contains multiple File objects, `is_default_file` **must** be defined as well.
+
 Creator, creator DID, attributes, files, properties and localization are optional and do not need to be included in the metadata.
+
+The `sha256_checksum` is also optional but recommended when using a file hosted at a centralized server. It allows NFT tooling to verify the image integrity, same for files where this property also applies.
 
 ### Field Specific Rationale
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -233,7 +233,7 @@ Note that mime types for directories are not uniformly defined. Some IPFS CIDs p
 
 ## Reference Implementation
 
-### Collectibe Hedera NFTs: HIP412
+### Example Schema: Collectibe Hedera NFTs (format: "HIP412")
 
 This is a **recommended reference implementation for collectible Hedera NFTs**. The `HIP412` standard has been designed to be used by all NFT tooling (wallets, explorers) and be mostly compatible with other existing standards. 
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -396,27 +396,27 @@ This is an example of a basic metadata as described by this schema. Format "none
 
 ```json
 {
-    "name": "Example NFT",
-    "creator": "Jane Doe, John Doe",
-    "description": "This is an example NFT metadata",
+	"name": "Example NFT",
+	"creator": "Jane Doe, John Doe",
+	"description": "This is an example NFT metadata",
 	"image": "ipfs://bafkreibwci24bt2xtqi23g35gfx63wj555u77lwl2t55ajbfjqomgefxce",
 	"type": "image/jpg",
-    "format": "none",
-    "files": [
-        {
-            "uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
-            "type": "video/mp4",
-            "metadata": {
-                "name": "video name",
-                "description": "nested file metadata",
-                "image": "ipfs://bakcjlajeioajflakdjfneafoaeinovandklf",
-                "format": "none",
-                "properties": {
-                    "additional_description": "The image in this nested metadata is the video thumbnail."
-                }
-            }
-        }
-    ]
+	"format": "none",
+	"files": [
+		{
+			"uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
+			"type": "video/mp4",
+			"metadata": {
+				"name": "video name",
+				"description": "nested file metadata",
+				"image": "ipfs://bakcjlajeioajflakdjfneafoaeinovandklf",
+				"format": "none",
+				"properties": {
+					"additional_description": "The image in this nested metadata is the video thumbnail."
+				}
+			}
+		}
+	]
 }
 ```
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -231,7 +231,7 @@ Note that mime types for directories are not uniformly defined. Some IPFS CIDs p
 
 ## Reference Implementation
 
-### Example Schema: Collectibe Hedera NFTs (format: "HIP412")
+### Example Schema: Collectibe Hedera NFTs (format: "HIP412@1.0.0")
 
 This is a **recommended reference implementation for collectible Hedera NFTs**. The `HIP412` standard has been designed to be used by all NFT tooling (wallets, explorers) and be mostly compatible with other existing standards. 
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -387,35 +387,70 @@ For more info see here: https://json-schema.org/
             "type": "string",
             "description": "Identifies the asset to which this token represents."
         },
+        "creator": {
+			"type": "string",
+			"description": "Identifies the artist name(s)."
+		},
+		"creatorDID": {
+			"type": "string",
+			"format": "uri",
+			"description": "Points to a decentralized identifier to identify the creator.",
+		},
         "description": {
             "type": "string",
             "description": "Describes the asset to which this token represents."
         },
         "image": {
             "type": "string",
+            "format": "uri",
             "description": "A URI pointing to a resource. Conditionally Optional."
         },
+        "sha256_checksum": {
+			"type": "string",
+			"description": "Cryptographic hash of the representation of the 'image' resource."
+		},
         "type": {
             "type": "string",
             "description": "Mime type of image. Required if image is defined."
         },
         "files": {
-            "type": "object",
+            "type": "array",
+            "contains": {
+				"type": "object"
+			},
             "description": "Array of files.",
-            "properties": {
+            "items": {
                 "uri": {
                     "type": "string",
+                    "format": "uri",
                     "description": "A URI pointing to a resource."
+                },
+                "sha256_checksum": {
+                    "type": "string",
+                    "description": "Cryptographic hash of the representation of the 'uri' resource."
                 },
                 "type": {
                     "type": "string",
                     "description": "Mime type of the resource."
+                },
+                "is_default_file": {
+                    "type": "boolean",
+                    "description": "Indicates if this file object is the main file representing the NFT."
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Represents a nested metadata object for the file."
                 },
                 "metadata_uri": {
                     "type": "string",
                     "description": "uri pointing to the metadata for this file"
                 }
             },
+            "required": [
+                "uri",
+                "type"
+            ],
+            "additionalProperties": false
         },
         "format": {
             "type": "string",
@@ -423,21 +458,25 @@ For more info see here: https://json-schema.org/
         },
         "properties": {
             "type": "object",
-            "description": "Optional. Arbitrary properties. Values may be strings, numbers, object or arrays."
+            "description": "Optional. Arbitrary properties. Values may be strings, numbers, booleans, objects or arrays."
         },
         "localization": {
-            "type": "object",
+            "type": "array",
             "description": "Array of localized metadata.",
-            "properties": {
+            "items": {
                 "uri": {
                     "type": "string",
+                    "format": "uri",
                     "description": "A URI pointing to the localized metadata json file for this locale."
                 },
                 "locale": {
                     "type": "string",
                     "description": "A two-letter locale."
                 }
-            }
+            },
+            "required": [
+                "locale"
+            ],
         },            
     },
     "required": [ "name" ]

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -2,7 +2,7 @@
 hip: 412
 title: NFT Token Metadata JSON Schema v2
 author: May Chan <may@hashpack.app>
-working-group: Cooper Kuntz <@Cooper-Kunz>, Paul Madsen <@paulatcalaxy>, Patches <@HGP_Patches>, DPub <@dpubbrewmaster>, Ashe Oro <@Ashe_Oro>, Brandon Davenport <@itsbrandond>, Justyn <@justynjj>, minteralogy <@minteralogy>, Michiel Mulders <@michielmulders>
+working-group: Cooper Kuntz <@Cooper-Kunz>, Paul Madsen <@paulatcalaxy>, HGP Patches <@HGP_Patches>, D Pub <@dpubbrewmaster>, Ashe Oro <@Ashe_Oro>, Brandon Davenport <@itsbrandond>, Justyn Spooner <@justynjj>, mint eralogy <@minteralogy>, Michiel Mulders <@michielmulders>
 type: Informational
 needs-council-approval: No
 status: Active

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -2,7 +2,7 @@
 hip: 412
 title: NFT Token Metadata JSON Schema v2
 author: May Chan <may@hashpack.app>
-working-group: Cooper Kuntz (@Cooper-Kunz), Paul Madsen (@paulatcalaxy), Patches (@HGP_Patches), DPub (@dpubbrewmaster), Ashe Oro (@Ashe_Oro), Brandon Davenport (@itsbrandond), Justyn (@justynjj), minteralogy (@minteralogy)
+working-group: Cooper Kuntz <@Cooper-Kunz>, Paul Madsen <@paulatcalaxy>, Patches <@HGP_Patches>, DPub <@dpubbrewmaster>, Ashe Oro <@Ashe_Oro>, Brandon Davenport <@itsbrandond>, Justyn <@justynjj>, minteralogy <@minteralogy>, Michiel Mulders <@michielmulders>
 type: Informational
 needs-council-approval: No
 status: Active
@@ -10,7 +10,7 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discuss
 replaces: 10
 last-call-date-time: 2022-04-15T07:00:00Z
 created: 2022-04-01
-updated: 2022-04-27
+updated: 2022-04-27, 2022-09-20
 ---
 
 ## Abstract

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -363,14 +363,14 @@ _Type: string (two-letter language code according to [ISO 639-1 standard](https:
 
 #### localization.is_default_locale
 
-(Optional) Indicates the primary language for this NFT. When multiple locales are listed, make sure to add this property to set the default locale for this metadata file. When `is_default_locale` is set, the `uri` property should not be defined for this localization object.
+(Conditionally Required) Indicates the primary language for this NFT. When multiple locales are listed, make sure to add this property to set the default locale for this metadata file. When `is_default_locale` is set, the `uri` property should not be defined for this localization object.
 
 _Type: boolean (false/true)_
 
 
 #### localization.uri
 
-(Required) CID or path to the localized NFT's metadata file. It's recommended to host your file on [IPFS](https://ipfs.io/) and use a service like [Pinata](https://pinata.cloud/) to easily pin your file. Your CID should look like this: `ipfs://<hash>`.
+(Conditionally Required) CID or path to the localized NFT's metadata file. It's recommended to host your file on [IPFS](https://ipfs.io/) and use a service like [Pinata](https://pinata.cloud/) to easily pin your file. Your CID should look like this: `ipfs://<hash>`.
 
 Alternatively, you can use [Arweave](https://www.arweave.org/), receiving a similar CID that looks like this: `ar://<hash>`.
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -323,7 +323,7 @@ Here's a clarification for the most important fields for the `HIP412@1.0.0` form
 
 #### image
 
-(Required) The `image` field can both serve as a preview image or the default image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Use the `is_default_file` in your `files` array to mark a file as the one you would prefer to have displayed by default if the NFT tooling supports it. In this case, the `image` field serves as a preview image or 'thumbnail'. **The standard recommends using the `image` field as a preview image by marking another file in the `files` array as default.**
+(Required) The standard **recommends** using the `image` field as a preview image/'thumbnail' by marking another file in the `files` array as the default high resoltion image using `is_default_file`.
 
 
 #### attributes.trait_type

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -114,11 +114,11 @@ https://w3c.github.io/did-core/
 
 Points to the uri of the image file. See **[uri formatting]** section for more details.
 
-If one or more files are defined under "files", "image" is considered to be the thumbnail that represents the collection of files. The term ‘thumbnail’ does not imply that the image size is reduced; "image" should always be the full resolution image. 
+If one or more files are defined under "files", "image" is considered to be the thumbnail that represents the array of files. The term ‘thumbnail’ does not imply that the image size is reduced; "image" should always be the full resolution image. 
 
-"image" was originally listed as ‘required’, however HashAxis noted that in the case of file NFTs, creating both image and file would require two files to pin instead of one. At the scale of millions, this doubling of the number of pinned images is significantly impactful to the cost of hosting the files. For files that can have their thumbnails generated programmatically, an image is not required. Because of this, the "image" field was changed to Conditionally Optional.
+"image" was originally listed as ‘required’, however HashAxis noted that in the case of file NFTs, creating both image and file would require two files to pin instead of one. At the scale of millions, this doubling of the number of pinned images is significantly impactful to the cost of hosting the files. For files that can have their thumbnails generated programmatically, an image is not required. Because of this, the "image" field was changed to Optional.
 
-"image" is a standard field across other chains. There was discussion to change this to a more generic name such as ‘file’ or ‘uri’, however this would break cross-chain compatibility of this standard. Although image is defined as conditionally optional, ensure that it is defined in formats such as opensea where it is required.
+"image" is a standard field across other chains. There was discussion to change this to a more generic name such as ‘file’ or ‘uri’, however this would break cross-chain compatibility of this standard. Although image is defined as optional, ensure that it is defined in formats such as opensea where it is required.
 
 #### sha256_checksum
 
@@ -239,7 +239,9 @@ This is a **recommended reference implementation for collectible Hedera NFTs**. 
 
 Here's an example of a full implementation of the metadata schema described in this `HIP412` specification for an image-based NFT. We are setting the image field to a URI and including the `sha256_checksum` field which represents a hash of the provided image. 
 
-The `files` array contains the main image hosted on IPFS, also including a checksum for validation purposes. The `image` field serves as a preview image for NFT tooling to quickly load. No additional properties are defined on the JSON object on root level. Any additional properties you want to define should go into the `properties` object.
+The `files` array contains the main image hosted on IPFS, also including an optional checksum for validation purposes. The `image` field serves as a preview image for NFT tooling where a programatically generated image doesn't work or you would like to have a different preview image. Therefore, the `image` field remains optional.
+
+Further, no additional properties are defined on the JSON object on root level. Any additional properties you want to define should go into the `properties` object.
 
 You can optionally define `attributes` to calculate rarity scores. We've added the field `display_type` similar to the OpenSea standard which defines how the attribute should be displayed.
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -355,7 +355,7 @@ _Type: string (two-letter language code according to [ISO 639-1 standard](https:
 
 #### localization.default
 
-(Required) Indicates the primary language for this NFT.
+(Required) Indicates the primary language for this NFT metadata specification. This locale should not be repeated in the `locales` array.
 
 _Type: string (two-letter language code according to [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))_
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -80,15 +80,15 @@ Below is the human-readable schema, presented to maximize clarity. This document
 
 ### Required, Optional and Conditionally Optional fields:
 
-Name, description and image are the three basic fields in ERC721 NFT standards. Name is **required** for all NFT’s. Description and image are optional, but recommended to enable apps to display them better.
+`name`, `description`, and `image` are the three basic fields in ERC721 NFT standards. A `name` is **required** for all NFT’s. The `description` and `image` fields are optional, but recommended to enable apps to display them better.
 
-Type is listed as *Conditionally Optional*. If Image is defined, then type **must** be defined as well.
+The `type` field is listed as *Conditionally Optional*. If `image` is defined, then `type` **must** be defined as well.
 
-`is_default_file` is listed as *Conditionally Optional*. If the Files array contains multiple File objects, `is_default_file` **must** be defined as well.
+`is_default_file` is listed as *Conditionally Optional*. If the `files` array contains multiple file objects, `is_default_file` **must** be defined as well.
 
-Creator, creator DID, attributes, files, properties and localization are optional and do not need to be included in the metadata.
+`creator`, `creator DID`, `attributes`, `files`, `properties` and `localization` are optional and do not need to be included in the metadata.
 
-The `sha256_checksum` is also optional but recommended when using a file hosted at a centralized server. It allows NFT tooling to verify the image integrity, same for files where this property also applies.
+The `sha256_checksum` is also optional but recommended when using a file hosted at a centralized server. It allows NFT tooling to verify the image integrity, same for `files` where this property also applies.
 
 ### Field Specific Rationale
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -205,7 +205,7 @@ If localization is defined, an application may choose to use the localized metad
 
 URI’s shall follow the following format: protocol://resource_location
 
-For resources that are on the world wide web, the standard http and https protocols are acceptable. Ie. http://www.example.org/image/file.jpg
+For resources that are on the world wide web, the standard https protocol is acceptable. Ie. http://www.example.org/image/file.jpg
 
 For resources that are on IPFS, the protocol must be ipfs:// and the resource location must be the cid of the file. Ie. ipfs://bafkreibwci24bt2xtqi23g35gfx63wj555u77lwl2t55ajbfjqomgefxce
 
@@ -481,49 +481,7 @@ An example similar to the above one. Format "none" is used to indicate that this
 }
 ```
 
-### Example Schema: opensea
 
-This is an example of an opensea-compatible metadata that includes the important collectible NFT field "attributes" which is used for rarity. It also places the "files" array in the properties field, which is consistent with the opensea standard.
-```json
-{
-    "name": "Example opensea NFT",
-    "creator": "Jim Doe",
-    "description": "This is an example of an opensea NFT metadata",
-    "image": "ipfs://bafkreibwci24bt2xtqi23g35gfx63wj555u77lwl2t55ajbfjqomgefxce",
-    "type": "image/gif",
-    "format": "opensea",
-    "attributes": [
-        {
-            "trait_type": "coolness",
-            "value": "50",
-            "max_value": "100",
-        },
-        {
-            "trait_type": "color",
-            "value": "red"
-        }
-    ],
-    "properties": {
-        "files": [
-            {
-                "uri": "https://www.image.net/abcd5678?ext=png",
-                "type": "image/png"
-            },
-            {
-                "uri": "https://www.arweave.net/efgh1234?ext=mp4",
-                "type": "video/mp4",
-            }
-        ],
-        "category": "video",
-        "creators": [
-            {
-                "address": "xEtQ9Fpv62qdc1GYfpNReMasVTe9YW5bHJwfVKqo72u"
-            }
-        ]
-    },
-    "external_url": "https://www.exampleNFT.com/3",
-}
-```
 ## Formal JSON Schema Definition
 
 The following is the formal definition of this schema using JSON Schema notation. JSON Schema assists in metadata validation and describes the data in the schema in more formal terms. **Despite looking like JSON, this is NOT how actual metadata should look. If you are creating the metadata file for an NFT do not use this definition as a reference.**

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -172,9 +172,9 @@ This allows NFT creators, communities and platforms to explicitly define the sch
 
 To reduce errors, "format" should be lower-case. For robustness, galleries and viewers should interpret format in a case-insensitive way to account for mistakes.
 
-If format is not defined, it is assumed to be "opensea", which is described here: https://docs.opensea.io/docs/metadata-standards . "opensea" can (and should) also be explicitly defined by format, where applicable, rather than leaving it blank. 
+For the purposes of this base metadata schema we also define `"format": "none"`, which is a catch-all that explicitly states that the NFT only follows the base fields of the schema but may define any number of additional fields.
 
-For the purposes of this base metadata schema we also define "format": "none", which is a catch-all that explicitly states that the NFT only follows the base fields of the schema but may define any number of additional fields.
+Other possible values for this schema are: `HIP412@1.0.0` and `opensea`. When you leave the `format` field blank, it is assumed you are using the [`HIP412@1.0.0` standard](https://gist.github.com/michielmulders/571c496789ede04c9074817cee834246). This standard can evolve. Therefore, semantic versioning has been applied to the standard. The first version of the standard is represented by `HIP412@1.0.0`.
 
 #### properties
 
@@ -194,6 +194,8 @@ Localization is an optional array of localization objects, which allow tokens/ap
 Each localization attribute is a sub-object with two attributes: uri and locale.
 
 uri - A URI to localized metadata in the specified locale. An application utilizing this metadata would discard the original metadata and use the localized metadata. It is the responsibility of the token creator to ensure that all non-localized fields and information is duplicated across the localized and base metadata.
+
+is_default_locale - Indicates the primary language for this NFT. When multiple locales are listed, make sure to add this property to set the default locale for this metadata file. When `is_default_locale` is set, the `uri` property should not be defined for this localization object because the current metadata represents this locale.
 
 locale - Specified two-letter language code, ie. en , fr , es per [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
 
@@ -247,7 +249,7 @@ You can optionally define `attributes` to calculate rarity scores. We've added t
 
 The standard also allows for localization. Each locale links to another metadata file that contains the localized metadata and files. This allows for a clean metadata structure. Don't define another localization object for a localized metadata file to avoid infinite looping when parsing an NFT's metadata file.
 
-**A JSON schema can be found [here](https://gist.github.com/michielmulders/1565e7759d692b65fa8c38cfe15b010c).**
+**A JSON schema can be found [here](https://gist.github.com/michielmulders/571c496789ede04c9074817cee834246). This is version v1.0.0, representing format `HIP412@1.0.0`.**
 
 ```json
 {
@@ -258,7 +260,7 @@ The standard also allows for localization. Each locale links to another metadata
 	"image": "https://myserver.com/nft-001.png",
 	"sha256_checksum": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	"type": "image/png",
-	"format": "HIP412",
+	"format": "HIP412@1.0.0",
 	"properties" : {
 		"external_url": "https://nft.com/mycollection/001"
 	},
@@ -298,7 +300,7 @@ The standard also allows for localization. Each locale links to another metadata
 		{
 			"trait_type": "birth",
 			"display_type": "datetime",
-			"value": "23-03-1993"
+			"value": "732844800"
 		}
 	],
 	"localization": [
@@ -308,11 +310,11 @@ The standard also allows for localization. Each locale links to another metadata
 		},
 		{
 			"locale": "es",
-			"metadata_uri": "ipfs://keiyidooajiaefklankfldanmfoieoakddqtyty"
+			"uri": "ipfs://keiyidooajiaefklankfldanmfoieoakddqtyty"
 		},
 		{
 			"locale": "jp",
-			"metadata_uri": "ipfs://yidooajiaefiakfldanm12554woakoakga4sfda"
+			"uri": "ipfs://yidooajiaefiakfldanm12554woakoakga4sfda"
 		}
 	]
 }
@@ -361,18 +363,18 @@ _Type: string (two-letter language code according to [ISO 639-1 standard](https:
 
 #### localization.is_default_locale
 
-(Optional) Indicates the primary language for this NFT. When multiple locales are listed, make sure to add this property to set the default locale for this metadata file. When `is_default_locale` is set, the `metadata_uri` property should not be defined for this localization object.
+(Optional) Indicates the primary language for this NFT. When multiple locales are listed, make sure to add this property to set the default locale for this metadata file. When `is_default_locale` is set, the `uri` property should not be defined for this localization object.
 
 _Type: boolean (false/true)_
 
 
-#### localization.metadata_uri
+#### localization.uri
 
 (Required) CID or path to the localized NFT's metadata file. It's recommended to host your file on [IPFS](https://ipfs.io/) and use a service like [Pinata](https://pinata.cloud/) to easily pin your file. Your CID should look like this: `ipfs://<hash>`.
 
 Alternatively, you can use [Arweave](https://www.arweave.org/), receiving a similar CID that looks like this: `ar://<hash>`.
 
-When `is_default_locale` is set, don't define the `metadata_uri` property because it indicates the default language for this NFT's metadata.
+When `is_default_locale` is set, don't define the `uri` property because it indicates the default language for this NFT's metadata.
 
 
 ### Example Schema: none
@@ -545,7 +547,7 @@ For more info see here: https://json-schema.org/
 		"image": {
 			"type": "string",
 			"format": "uri",
-			"description": "A URI pointing to a resource. Conditionally Optional."
+			"description": "A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
 		},
 		"sha256_checksum": {
 			"type": "string",
@@ -610,6 +612,10 @@ For more info see here: https://json-schema.org/
 					"type": "string",
 					"format": "uri",
 					"description": "A URI pointing to the localized metadata json file for this locale."
+				},
+				"is_default_locale": {
+					"type": "boolean",
+					"description": "Indicates if the set locale is the default locale for this metadata file."
 				},
 				"locale": {
 					"type": "string",

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -233,7 +233,141 @@ Note that mime types for directories are not uniformly defined. Some IPFS CIDs p
 
 ## Reference Implementation
 
-#### Example Schema: none
+### Collectibe Hedera NFTs: HIP412
+
+This is a **recommended reference implementation for collectible Hedera NFTs**. The `HIP412` standard has been designed to be used by all NFT tooling (wallets, explorers) and be mostly compatible with other existing standards. 
+
+Here's an example of a full implementation of the metadata schema described in this `HIP412` specification for an image-based NFT. We are setting the image field to a URI and including the `sha256_checksum` field which represents a hash of the provided image. 
+
+The `files` array contains the main image hosted on IPFS, also including a checksum for validation purposes. The `image` field serves as a preview image for NFT tooling to quickly load. No additional properties are defined on the JSON object on root level. Any additional properties you want to define should go into the `properties` object.
+
+You can optionally define `attributes` to calculate rarity scores. We've added the field `display_type` similar to the OpenSea standard which defines how the attribute should be displayed.
+
+The standard also allows for localization. Each locale links to another metadata file that contains the localized metadata and files. This allows for a clean metadata structure.
+
+```json
+{
+	"name": "Example NFT 001",
+	"creator": "Jane Doe, John Doe",
+	"creatorDID": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm;hedera:mainnet:fid=0.0.123",
+	"description": "This describes my NFT",
+	"image": "https://myserver.com/nft-001.png",
+	"sha256_checksum": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+	"type": "image/png",
+	"format": "HIP412",
+	"properties" : {
+		"external_url": "https://nft.com/mycollection/001"
+	},
+	"files": [
+		{
+			"uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
+			"sha256_checksum": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            "is_default_file": true,
+			"type": "image/png"
+		},
+        {
+			"uri": "ipfs://yusopwpksaioposjfopiapnnjlsl",
+			"type": "image/png"
+		}
+	],
+	"attributes": [
+		{
+			"trait_type": "colour",
+			"value": "red"
+		},
+		{
+			"trait_type": "hasPipe",
+			"value": true
+		},
+		{
+			"trait_type": "coolness",
+			"display_type": "boost",
+			"value": 10,
+			"max_value": 100
+		},
+		{
+			"trait_type": "stamina",
+			"display_type": "percentage",
+			"value": 83
+		}
+		,
+		{
+			"trait_type": "birth",
+			"display_type": "datetime",
+			"value": "23-03-1993"
+		}
+	],
+	"localization": [
+		{
+			"locale": "en",
+			"is_default_locale": true
+		},
+		{
+			"locale": "es",
+			"metadata_uri": "ipfs://keiyidooajiaefklankfldanmfoieoakddqtyty"
+		},
+		{
+			"locale": "jp",
+			"metadata_uri": "ipfs://yidooajiaefiakfldanm12554woakoakga4sfda"
+		}
+	]
+}
+```
+
+Here's a clarification for the most important fields. 
+
+#### files
+
+The required `files` array holds one or many files. Because the `image` property is used as a preview image, the `files` array should at least hold one `file` object that represents the NFT. 
+
+#### attributes.trait_type
+
+Name of trait.
+
+### attributes.display_type
+
+(Optional) Indicates how the trait value should be displayed. Possible display types (but other types are allowed):
+
+- `text` (**default value representation**)
+- `percentage` (for integer or number values)
+- `boost` (for integer or number values)
+- `datetime` (for string values)
+
+
+#### attributes.value
+
+(Required) Value for trait. To give an example, imagine an NFT with the `trait_type: mouth`. Possible values are `bubblegum`, `smiling`, `braces`, or `trumpet`. 
+
+**Type:** Allowed types: string, integer, number, boolean
+
+#### attributes.max_value
+
+(Optional) Adding a `max_value` sets a ceiling for a numerical trait's possible values. **NFT tooling should default this value to the maximum value seen for a collection.** Only use this property if you want to set a different value than the maximum value seen in the collection. Make sure the `max_value` is equal to or higher than the maximum value seen for your collection.
+
+#### localization.locale
+
+(Required) A two-letter language code identifying the file's language. No need to further define subregion locales such as `en-GB` to keep things simple.
+
+**Type:** string (two-letter language code according to [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))
+
+
+#### localization.is_default_locale
+
+(Optional) Indicates the primary language for this NFT. When multiple locales are listed, make sure to add this property to set the default locale for this metadata file. When `is_default_locale` is set, the `metadata_uri` property should not be defined for this localization object.
+
+**Type:** boolean (false/true)
+
+
+#### localization.metadata_uri
+
+(Required) CID or path to the localized NFT's metadata file. It's recommended to host your file on [IPFS](https://ipfs.io/) and use a service like [Pinata](https://pinata.cloud/) to easily pin your file. Your CID should look like this: `ipfs://<hash>`.
+
+Alternatively, you can use [Arweave](https://www.arweave.org/), receiving a similar CID that looks like this: `ar://<hash>`.
+
+When `is_default_locale` is set, don't define the `metadata_uri` property because it indicates the default language for this NFT's metadata.
+
+
+### Example Schema: none
 
 This is an example of a basic metadata as described by this schema. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. Note that all the fields in properties are arbitrary.
 ```json
@@ -251,7 +385,7 @@ This is an example of a basic metadata as described by this schema. Format "none
     }
 }
 ```
-#### Example Schema: none, video
+### Example Schema: none, video
 
 This is an example of a basic metadata as described by this schema. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. Note that this NFT does not include an image, nor does it define any arbitrary properties.
 ```json
@@ -278,7 +412,7 @@ This is an example of a basic metadata as described by this schema. Format "none
 }
 ```
 
-#### Example Schema: none, video, multiple files, localization
+### Example Schema: none, video, multiple files, localization
 
 An example similar to the above one. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. The NFT does not contain a thumbnail, but some of the sub-files define their own thumbnails and localizations. The localization attributes would point to localized metadata for each sub-file.
 ```json
@@ -330,7 +464,7 @@ An example similar to the above one. Format "none" is used to indicate that this
 }
 ```
 
-#### Example Schema: opensea
+### Example Schema: opensea
 
 This is an example of an opensea-compatible metadata that includes the important collectible NFT field "attributes" which is used for rarity. It also places the "files" array in the properties field, which is consistent with the opensea standard.
 ```json

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -266,10 +266,10 @@ The standard also allows for localization. Each locale links to another metadata
 		{
 			"uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
 			"sha256_checksum": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-            "is_default_file": true,
+			"is_default_file": true,
 			"type": "image/png"
 		},
-        {
+		{
 			"uri": "ipfs://yusopwpksaioposjfopiapnnjlsl",
 			"type": "image/png"
 		}

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -60,7 +60,7 @@ Below is the human-readable schema, presented to maximize clarity. This document
         {
             "uri": "uri to file",
             "sha256_checksum": "cryptographic hash of the representation of the resource the author expects to load - OPTIONAL",
-            "is_default_file": "(Type: boolean) indicates if the file is the main file for this NFT - CONDITIONALLY OPTIONAL",
+            "is_default_file": "(Type: boolean) indicates if the file is the main file for this NFT - OPTIONAL",
             "type": "mime type",
             "metadata": "metadata object - OPTIONAL",
             "metadata_uri": "uri to metadata - OPTIONAL"
@@ -151,7 +151,7 @@ Including the mime type allows applications to properly handle the file and grea
 
 "type" is required and is the mime-type of the file pointed to by the uri, see [Mime Formatting]
 
-"is_default_file" is required when multiple file objects are listed for the files array. It allows the user to define which file is the default file for the NFT. If a single file is listed, this file becomes the default file. Therefore, the field is optional.
+"is_default_file" is optional and allows the user to define which file is the default file for the NFT. It's useful when you want to define another file as the default file your NFT than the one listed in the `image` field. It can also be used for indicating the main file for a multi-file NFT. 
 
 “metadata” is optional. This is a nested metadata object for the file, which follows the same metadata format as the root metadata. Files can be nested indefinitely in this way, but processed with the same metadata code.
 
@@ -316,7 +316,7 @@ The standard also allows for localization. Each locale links to another metadata
 }
 ```
 
-Here's a clarification for the most important fields for the `HIP412` format.
+Here's a clarification for the most important fields for the `HIP412@1.0.0` format.
 
 #### image
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -49,32 +49,32 @@ Below is the human-readable schema, presented to maximize clarity. This document
 
 ```json
 {
-    "name": "token Name - REQUIRED",
-    "creator": "artist",
-    "creatorDID": "DID URI",
-    "description": "human readable description of the asset - RECOMMENDED",
-    "image": "cid or path to the NFT's image file, or for non-image NFTs, optional preview image - REQUIRED",
-    "checksum": "SHA-256 digest of the file pointed by the image field - OPTIONAL",
-    "type": "mime type - ie image/jpeg - REQUIRED",
-    "files": [ // object array that contains uri, type and metadata
-        {
-            "uri": "uri to file - REQUIRED",
-            "checksum": "cryptographic SHA-256 hash of the representation of the resource the author expects to load - OPTIONAL",
-            "is_default_file": "(Type: boolean) indicates if the file is the main file for this NFT - OPTIONAL",
-            "type": "mime type - REQUIRED",
-            "metadata": "metadata object - OPTIONAL",
-            "metadata_uri": "uri to metadata - OPTIONAL"
-        },
-        … multiple …
-    ],
-    "format": "format designation",
-    "properties": {
-        // arbitrary json objects that cover the overarching properties of the token
-    },
-    "localization": [ 
-        // optional array of localization objects
-    ]
-    // additional fields defined per the format
+	"name": "token Name - REQUIRED",
+	"creator": "artist",
+	"creatorDID": "DID URI",
+	"description": "human readable description of the asset - RECOMMENDED",
+	"image": "cid or path to the NFT's image file, or for non-image NFTs, optional preview image - REQUIRED",
+	"checksum": "SHA-256 digest of the file pointed by the image field - OPTIONAL",
+	"type": "mime type - ie image/jpeg - REQUIRED",
+	"files": [ // object array that contains uri, type and metadata
+		{
+			"uri": "uri to file - REQUIRED",
+			"checksum": "cryptographic SHA-256 hash of the representation of the resource the author expects to load - OPTIONAL",
+			"is_default_file": "(Type: boolean) indicates if the file is the main file for this NFT - OPTIONAL",
+			"type": "mime type - REQUIRED",
+			"metadata": "metadata object - OPTIONAL",
+			"metadata_uri": "uri to metadata - OPTIONAL"
+		},
+		… multiple …
+	],
+	"format": "format designation",
+	"properties": {
+		// arbitrary json objects that cover the overarching properties of the token
+	},
+	"localization": [ 
+		// optional array of localization objects
+	]
+	// additional fields defined per the format
 }
 ```
 
@@ -139,12 +139,12 @@ Including the mime type allows applications to properly handle the file and grea
 "files" is an array of objects with the following format:
 ```json
 {
-    "uri": "uri to file - REQUIRED",
-    "checksum": "cryptographic hash of the representation of the resource the author expects to load - OPTIONAL",
-    "type": "mime type - REQUIRED",
-    "is_default_file": true,
-    "metadata": "metadata object - OPTIONAL",
-    "metadata_uri": "uri to metadata - OPTIONAL"
+	"uri": "uri to file - REQUIRED",
+	"checksum": "cryptographic hash of the representation of the resource the author expects to load - OPTIONAL",
+	"type": "mime type - REQUIRED",
+	"is_default_file": true,
+	"metadata": "metadata object - OPTIONAL",
+	"metadata_uri": "uri to metadata - OPTIONAL"
 }
 ```
 "uri" is the uri to the file. See [URI Formatting]
@@ -377,17 +377,17 @@ The format of the uri should look like this `<protocol>://<hash>/{locale}.json`.
 This is an example of a basic metadata as described by this schema. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. Note that all the fields in properties are arbitrary.
 ```json
 {
-    "name": "Example NFT",
-    "creator": "John Doe",
-    "description": "This is an example NFT metadata",
-    "image": "ipfs://bafkreibwci24bt2xtqi23g35gfx63wj555u77lwl2t55ajbfjqomgefxce",
-    "type": "image/png",
-    "format": "none",
-    "properties": {
-        "license": "MIT-0",
-        "collection": "Generic Collection Name",
-        "website": "www.johndoe.com"
-    }
+	"name": "Example NFT",
+	"creator": "John Doe",
+	"description": "This is an example NFT metadata",
+	"image": "ipfs://bafkreibwci24bt2xtqi23g35gfx63wj555u77lwl2t55ajbfjqomgefxce",
+	"type": "image/png",
+	"format": "none",
+	"properties": {
+		"license": "MIT-0",
+		"collection": "Generic Collection Name",
+		"website": "www.johndoe.com"
+	}
 }
 ```
 ### Example Schema: none (video NFT)
@@ -432,47 +432,47 @@ An example similar to the above one. Format "none" is used to indicate that this
 	"image": "https://myserver.com/preview-image-001.png",
 	"checksum": "9defbb6402d4bf39f2ea580099c73194647b24a659b6f6b778e3dd71755b8862",
 	"type": "image/png",
-    "format": "none",
-    "files": [
-        {
-            "uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
-            "type": "video/mp4",
+	"format": "none",
+	"files": [
+		{
+			"uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
+			"type": "video/mp4",
 			"is_default_file": true,
-            "metadata": {
-                "name": "Example Video"
-            },
-            "localization": [
-                {
-                    "uri": "ipfs://dfa3tjaklfjoiaefklankfdf3d32zafga3tfD",
-                    "locale": "es"
-                },
-                {
-                    "uri": "ipfs://dija9jaklfjoiaefklankf13fsef36aga4fda",
-                    "locale": "jp"
-                }
-            ]
-        },
-        {
-            "uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
-            "type": "application/pdf",
-            "metadata": {
-                "name": "Example second file",
-                "description": "The description is recommended but optional. The image provided is an optional preview",
-                "image": "ipfs://bawlkjaklfjoiaefklankflda1313ieiajfl",
-                "type": "image/jpeg"
-            }
-        }
-    ],
-    "localization": [
-        {
-            "uri": "ipfs://bawlkjaklfjoiaefklankflda132zafga3tfa",
-            "locale": "es"
-        },
-        {
-            "uri": "ipfs://bawlkjaklfjoiaefklankf12554wa6aga4fda",
-            "locale": "jp"
-        }
-    ]
+			"metadata": {
+				"name": "Example Video"
+			},
+			"localization": [
+				{
+					"uri": "ipfs://dfa3tjaklfjoiaefklankfdf3d32zafga3tfD",
+					"locale": "es"
+				},
+				{
+					"uri": "ipfs://dija9jaklfjoiaefklankf13fsef36aga4fda",
+					"locale": "jp"
+				}
+			]
+		},
+		{
+			"uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
+			"type": "application/pdf",
+			"metadata": {
+				"name": "Example second file",
+				"description": "The description is recommended but optional. The image provided is an optional preview",
+				"image": "ipfs://bawlkjaklfjoiaefklankflda1313ieiajfl",
+				"type": "image/jpeg"
+			}
+		}
+	],
+	"localization": [
+		{
+			"uri": "ipfs://bawlkjaklfjoiaefklankflda132zafga3tfa",
+			"locale": "es"
+		},
+		{
+			"uri": "ipfs://bawlkjaklfjoiaefklankf12554wa6aga4fda",
+			"locale": "jp"
+		}
+	]
 }
 ```
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -187,7 +187,7 @@ It is not in the scope of this schema to define field naming standards or common
 Best Practice Recommendation: **It is strongly recommended that information such as ‘supply’, ‘royalties’ and other properties which are recorded on ledger should not be defined in the metadata.** This information is at best redundant and at worst can be factually incorrect.
 
 
-#### Localization
+#### localization
 
 Localization is an optional array of localization objects, which allow tokens/applications to present data uniformity across all languages.
 
@@ -318,15 +318,15 @@ The standard also allows for localization. Each locale links to another metadata
 }
 ```
 
-Here's a clarification for the most important fields. 
+Here's a clarification for the most important fields for the `HIP412` format.
 
 #### files
 
-The required `files` array holds one or many files. Because the `image` property is used as a preview image, the `files` array should at least hold one `file` object that represents the NFT. 
+(Required) `files` array holds one or many files. Because the optional `image` property can be used as a preview image, the `files` array should at least hold one `file` object that represents the NFT. 
 
 #### attributes.trait_type
 
-Name of trait.
+(Required) Name of trait.
 
 ### attributes.display_type
 
@@ -335,35 +335,35 @@ Name of trait.
 - `text` (**default value representation**)
 - `percentage` (for integer or number values)
 - `boost` (for integer or number values)
-- `datetime` (for a number which represents the unix timestamp in seconds )
-- `date` (for a number which represents the unix timestamp in seconds )
-- `color` (for a hexadecimal or rgb string color sequence such as "#00ff44" or "rgb(0,255,0)" )
+- `datetime` (for a number which represents the unix timestamp in seconds)
+- `date` (for a number which represents the unix timestamp in seconds)
+- `color` (for a hexadecimal or rgb string color sequence such as `#00ff44` or `rgb(0,255,0)`)
 
 
 #### attributes.value
 
 (Required) Value for trait. To give an example, imagine an NFT with the `trait_type: mouth`. Possible values are `bubblegum`, `smiling`, `braces`, or `trumpet`. 
 
-**Allowed types:** string, integer, number, boolean
+_Allowed types: string, integer, number, boolean_
 
 #### attributes.max_value
 
 (Optional) Adding a `max_value` sets a ceiling for a numerical trait's possible values. **NFT tooling should default this value to the maximum value seen for a collection.** Only use this property if you want to set a different value than the maximum value seen in the collection. Make sure the `max_value` is equal to or higher than the maximum value seen for your collection.
 
-**Allowed types:** string, integer, number
+_Allowed types: string, integer, number_
 
 #### localization.locale
 
 (Required) A two-letter language code identifying the file's language. No need to further define subregion locales such as `en-GB` to keep things simple.
 
-**Type:** string (two-letter language code according to [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))
+_Type: string (two-letter language code according to [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))_
 
 
 #### localization.is_default_locale
 
 (Optional) Indicates the primary language for this NFT. When multiple locales are listed, make sure to add this property to set the default locale for this metadata file. When `is_default_locale` is set, the `metadata_uri` property should not be defined for this localization object.
 
-**Type:** boolean (false/true)
+_Type: boolean (false/true)_
 
 
 #### localization.metadata_uri

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -354,7 +354,7 @@ _Allowed types: string, integer, number_
 
 ### Example Schema: Image NFT with no format defined
 
-This is an example of a basic metadata as described by this schema. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. Note that all the fields in properties are arbitrary.
+This is an example of a basic metadata as described by this schema. No specific format is used to indicate that this metadata does not adhere to any specific sub-schema. Note that all the fields in properties are arbitrary.
 ```json
 {
 	"name": "Example NFT",
@@ -371,7 +371,7 @@ This is an example of a basic metadata as described by this schema. Format "none
 ```
 ### Example Schema: Video NFT with no format defined
 
-This is an example of a basic metadata as described by this schema. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. Note that this NFT does not include an image, nor does it define any arbitrary properties.
+This is an example of a video NFT with no format defined. Note that this NFT does not include an image, nor does it define any arbitrary properties.
 
 ```json
 {
@@ -388,7 +388,6 @@ This is an example of a basic metadata as described by this schema. Format "none
 				"name": "video name",
 				"description": "nested file metadata",
 				"image": "ipfs://bakcjlajeioajflakdjfneafoaeinovandklf",
-				"format": "none",
 				"properties": {
 					"additional_description": "The image in this nested metadata is the video thumbnail."
 				}

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -54,12 +54,12 @@ Below is the human-readable schema, presented to maximize clarity. This document
     "creatorDID": "DID URI",
     "description": "human readable description of the asset - RECOMMENDED",
     "image": "cid or path to the NFT's image file, or for non-image NFTs, optional preview image - RECOMMENDED",
-    "sha256_checksum": "SHA-256 digest of the file pointed by the image field - OPTIONAL",
+    "checksum": "SHA-256 digest of the file pointed by the image field - OPTIONAL",
     "type": "mime type - ie image/jpeg - CONDITIONALLY OPTIONAL",
     "files": [ // object array that contains uri, type and metadata
         {
             "uri": "uri to file",
-            "sha256_checksum": "cryptographic hash of the representation of the resource the author expects to load - OPTIONAL",
+            "checksum": "cryptographic SHA-256 hash of the representation of the resource the author expects to load - OPTIONAL",
             "is_default_file": "(Type: boolean) indicates if the file is the main file for this NFT - OPTIONAL",
             "type": "mime type",
             "metadata": "metadata object - OPTIONAL",
@@ -86,7 +86,7 @@ The `type` field is listed as *Conditionally Optional*. If `image` is defined, t
 
 `creator`, `creator DID`, `attributes`, `files`, `properties` and `localization` are optional and do not need to be included in the metadata.
 
-The `sha256_checksum` is also optional but recommended when using a file hosted at a centralized server. It allows NFT tooling to verify the image integrity, same for `files` where this property also applies.
+The `checksum` is also optional but recommended when using a file hosted at a centralized server. It allows NFT tooling to verify the image integrity, same for `files` where this property also applies.
 
 ### Field Specific Rationale
 
@@ -116,11 +116,13 @@ The `image` field is required. It can both serve as a preview image or the defau
 
 "image" is a standard field across other chains and is required for this standard. There was discussion to change this to a more generic name such as ‘file’ or ‘uri’, however this would break cross-chain compatibility of this standard.
 
-#### sha256_checksum
+#### checksum
 
-SHA-256 digest of the file pointed by the `image` property. The `sha256_checksum` property that contains a cryptographic hash of the representation of the resource the author expects to load. 
+The `checksum` property represents a SHA-256 digest of the file pointed by the `image` property. The `checksum` property that contains a cryptographic hash of the representation of the resource the author expects to load. 
 
 For instance, an author may wish to load some image from a shared server. Specifying that the expected SHA-256 hash of https://example.com/image.jpeg is ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad means that the user agent can verify that the data it loads from that URL matches that expected hash before loading the NFT. This integrity verification significantly reduces the risk that an attacker can substitute malicious content.
+
+The hashing method can be updated in the future according to W3C guidelines. SHA256 is deemed a safe option for verifying resource integrity. However, hashing functions that are not recommended include MD5 and SHA-1.
 
 References: https://w3c.github.io/webappsec-subresource-integrity/
 
@@ -138,7 +140,7 @@ Including the mime type allows applications to properly handle the file and grea
 ```json
 {
     "uri": "uri to file",
-    "sha256_checksum": "cryptographic hash of the representation of the resource the author expects to load - OPTIONAL",
+    "checksum": "cryptographic hash of the representation of the resource the author expects to load - OPTIONAL",
     "type": "mime type",
     "is_default_file": true,
     "metadata": "metadata object - OPTIONAL",
@@ -147,7 +149,7 @@ Including the mime type allows applications to properly handle the file and grea
 ```
 "uri" is the uri to the file. See [URI Formatting]
 
-"sha256_checksum" is an optional cryptographic hash of the representation of the resource the author expects to load.
+"checksum" is an optional cryptographic SHA-256 hash of the representation of the resource the author expects to load.
 
 "type" is required and is the mime-type of the file pointed to by the uri, see [Mime Formatting]
 
@@ -235,7 +237,7 @@ Note that mime types for directories are not uniformly defined. Some IPFS CIDs p
 
 This is a **recommended reference implementation for collectible Hedera NFTs**. The `HIP412` standard has been designed to be used by all NFT tooling (wallets, explorers) and be mostly compatible with other existing standards. 
 
-Here's an example of a full implementation of the metadata schema described in this `HIP412` specification for an image-based NFT. We are setting the image field to a URI and including the `sha256_checksum` field which represents a hash of the provided image. 
+Here's an example of a full implementation of the metadata schema described in this `HIP412` specification for an image-based NFT. We are setting the image field to a URI and including the `checksum` field which represents a SHA-256 hash of the provided image. 
 
 The `files` array contains file objects (e.g. multi-file NFTs), also including an optional checksum for validation purposes. The `image` field can both serve as a preview image or the default image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Use the `is_default_file` in your `files` array to mark a file as the one you would prefer to have displayed by default if the NFT tooling supports it. In this case, the `image` field serves as a preview image. **The standard recommends using the `image` field as a preview image by marking another file in the `files` array as default.**
 
@@ -254,7 +256,7 @@ The standard also allows for localization. Each locale links to another metadata
 	"creatorDID": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm;hedera:mainnet:fid=0.0.123",
 	"description": "This describes my NFT",
 	"image": "https://myserver.com/preview-image-nft-001.png",
-	"sha256_checksum": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+	"checksum": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	"type": "image/png",
 	"format": "HIP412@1.0.0",
 	"properties" : {
@@ -263,7 +265,7 @@ The standard also allows for localization. Each locale links to another metadata
 	"files": [
 		{
 			"uri": "https://myserver.com/high-resolution-nft-001.png",
-			"sha256_checksum": "9defbb6402d4bf39f2ea580099c73194647b24a659b6f6b778e3dd71755b8862",
+			"checksum": "9defbb6402d4bf39f2ea580099c73194647b24a659b6f6b778e3dd71755b8862",
 			"is_default_file": true,
 			"type": "image/png"
 		},
@@ -433,7 +435,7 @@ An example similar to the above one. Format "none" is used to indicate that this
 	"creatorDID": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm;hedera:mainnet:fid=0.0.123",
 	"description": "This is an example NFT metadata",
 	"image": "https://myserver.com/preview-image-001.png",
-	"sha256_checksum": "9defbb6402d4bf39f2ea580099c73194647b24a659b6f6b778e3dd71755b8862",
+	"checksum": "9defbb6402d4bf39f2ea580099c73194647b24a659b6f6b778e3dd71755b8862",
 	"type": "image/png",
     "format": "none",
     "files": [
@@ -554,9 +556,9 @@ For more info see here: https://json-schema.org/
 			"format": "uri",
 			"description": "A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
 		},
-		"sha256_checksum": {
+		"checksum": {
 			"type": "string",
-			"description": "Cryptographic hash of the representation of the 'image' resource."
+			"description": "Cryptographic SHA-256 hash of the representation of the 'image' resource."
 		},
 		"type": {
 			"type": "string",
@@ -574,7 +576,7 @@ For more info see here: https://json-schema.org/
 					"format": "uri",
 					"description": "A URI pointing to a resource."
 				},
-				"sha256_checksum": {
+				"checksum": {
 					"type": "string",
 					"description": "Cryptographic hash of the representation of the 'uri' resource."
 				},

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -331,7 +331,9 @@ Name of trait.
 - `text` (**default value representation**)
 - `percentage` (for integer or number values)
 - `boost` (for integer or number values)
-- `datetime` (for string values)
+- `datetime` (for a number which represents the unix timestamp in seconds )
+- `date` (for a number which represents the unix timestamp in seconds )
+- `color` (for a hexadecimal or rgb string color sequence such as "#00ff44" or "rgb(0,255,0)" )
 
 
 #### attributes.value

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -112,7 +112,7 @@ https://w3c.github.io/did-core/
 
 A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive. See **[uri formatting]** section for more details.
 
-The `image` field is optional but recommended. It can both serve as a preview image or the default image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Use the `is_default_file` in your `files` array to mark a file as the one you would prefer to have displayed by default if the NFT tooling supports it. In this case, the `image` field serves as a preview image or 'thumbnail'.
+The `image` field is required. It can both serve as a preview image or the default image for your NFT to ensure cross-platform compatibility. The image will be displayed in wallets and marketplaces by default. Some platforms may support displaying other file types such as 3D files, audio or video. Use the `is_default_file` in your `files` array to mark a file as the one you would prefer to have displayed by default if the NFT tooling supports it. In this case, the `image` field serves as a preview image or 'thumbnail'.
 
 "image" is a standard field across other chains and is required for this standard. There was discussion to change this to a more generic name such as ‘file’ or ‘uri’, however this would break cross-chain compatibility of this standard.
 
@@ -128,7 +128,7 @@ References: https://w3c.github.io/webappsec-subresource-integrity/
 
 Mime type of the image file. See **[mime formatting]** section for more details.
 
-"type" is required if "image" is defined. 
+"type" is required because the "image" field is required.
 
 Including the mime type allows applications to properly handle the file and greatly simplifies the code required to display the data.
 
@@ -253,7 +253,7 @@ The standard also allows for localization. Each locale links to another metadata
 	"creator": "Jane Doe, John Doe",
 	"creatorDID": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm;hedera:mainnet:fid=0.0.123",
 	"description": "This describes my NFT",
-	"image": "https://myserver.com/nft-001.png",
+	"image": "https://myserver.com/preview-image-nft-001.png",
 	"sha256_checksum": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	"type": "image/png",
 	"format": "HIP412@1.0.0",
@@ -262,8 +262,8 @@ The standard also allows for localization. Each locale links to another metadata
 	},
 	"files": [
 		{
-			"uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
-			"sha256_checksum": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+			"uri": "https://myserver.com/high-resolution-nft-001.png",
+			"sha256_checksum": "9defbb6402d4bf39f2ea580099c73194647b24a659b6f6b778e3dd71755b8862",
 			"is_default_file": true,
 			"type": "image/png"
 		},
@@ -274,8 +274,9 @@ The standard also allows for localization. Each locale links to another metadata
 	],
 	"attributes": [
 		{
-			"trait_type": "colour",
-			"value": "red"
+			"trait_type": "color",
+			"display_type": "color",
+			"value": "rgb(255,0,0)"
 		},
 		{
 			"trait_type": "hasPipe",
@@ -296,7 +297,7 @@ The standard also allows for localization. Each locale links to another metadata
 		{
 			"trait_type": "birth",
 			"display_type": "datetime",
-			"value": "732844800"
+			"value": 732844800
 		}
 	],
 	"localization": [
@@ -401,6 +402,8 @@ This is an example of a basic metadata as described by this schema. Format "none
     "name": "Example NFT",
     "creator": "Jane Doe, John Doe",
     "description": "This is an example NFT metadata",
+	"image": "ipfs://bafkreibwci24bt2xtqi23g35gfx63wj555u77lwl2t55ajbfjqomgefxce",
+	"type": "image/jpg",
     "format": "none",
     "files": [
         {
@@ -425,15 +428,19 @@ This is an example of a basic metadata as described by this schema. Format "none
 An example similar to the above one. Format "none" is used to indicate that this metadata does not adhere to any specific sub-schema. The NFT does not contain a thumbnail, but some of the sub-files define their own thumbnails and localizations. The localization attributes would point to localized metadata for each sub-file.
 ```json
 {
-    "name": "Example NFT",
-    "creator": "Jane Doe, John Doe",
-    "creatorDID": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm;hedera:mainnet:fid=0.0.123",
-    "description": "This is an example NFT metadata",
+	"name": "Example NFT",
+	"creator": "Jane Doe, John Doe",
+	"creatorDID": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm;hedera:mainnet:fid=0.0.123",
+	"description": "This is an example NFT metadata",
+	"image": "https://myserver.com/preview-image-001.png",
+	"sha256_checksum": "9defbb6402d4bf39f2ea580099c73194647b24a659b6f6b778e3dd71755b8862",
+	"type": "image/png",
     "format": "none",
     "files": [
         {
             "uri": "ipfs://bawlkjaklfjoiaefklankfldanmfoieiajfl",
             "type": "video/mp4",
+			"is_default_file": true,
             "metadata": {
                 "name": "Example Video"
             },
@@ -490,9 +497,9 @@ This is an example of an opensea-compatible metadata that includes the important
             "max_value": "100",
         },
         {
-            "trait_type": "colour",
+            "trait_type": "color",
             "value": "red"
-        },
+        }
     ],
     "properties": {
         "files": [
@@ -625,7 +632,7 @@ For more info see here: https://json-schema.org/
 			],
 		},
 	},
-	"required": [ "name" ]
+	"required": [ "name", "image", "type" ]
 }
 ```
 

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -243,7 +243,7 @@ The `files` array contains the main image hosted on IPFS, also including a check
 
 You can optionally define `attributes` to calculate rarity scores. We've added the field `display_type` similar to the OpenSea standard which defines how the attribute should be displayed.
 
-The standard also allows for localization. Each locale links to another metadata file that contains the localized metadata and files. This allows for a clean metadata structure.
+The standard also allows for localization. Each locale links to another metadata file that contains the localized metadata and files. This allows for a clean metadata structure. Don't define another localization object for a localized metadata file to avoid infinite looping when parsing an NFT's metadata file.
 
 ```json
 {


### PR DESCRIPTION
**Description**:

- This PR adds a reference implementation for collectible NFTs using the baseline implementation defined by HIP412 to make it easier for NFT tooling to parse collectible NFTs. You can view the [reference JSON schema here](https://gist.github.com/michielmulders/571c496789ede04c9074817cee834246) -> host it somewhere else?
- This PR also adds new fields to the base implementation to make it more robust (`is_default_file` and `sha256_checksum`).
- Sets `image` as optional (if defined, it's used as the preview image - otherwise it's programmatically created) -> therefore `files` array is required because it should have at least one file listed which is the default file for the NFT. 
- Changed `image` from conditionally optional to optional because `type` is conditionally optional and not the other way round.

