### PR TITLE
Add maxPriorityFeePerGas to HIP-482

### DIFF
--- a/HIP/hip-482.md
+++ b/HIP/hip-482.md
@@ -1,11 +1,11 @@
 ---
 hip: 482
-title: JSON-RPC Relay 
+title: JSON-RPC Relay
 author: Mitchell Martin <mitch@swirldslabs.com>, Steven Sheehy <steven.sheehy@swirldslabs.com>
 working-group: Daniel Ivanov <daniel-k-ivanov95@gmail.com>, Danno Ferrin <danno.ferrin@swirldslabs.com>, Richard Bair <richard.bair@swirldslabs.com>
-type: Standards Track 
-category: Application 
-needs-council-approval: No 
+type: Standards Track
+category: Application
+needs-council-approval: No
 status: Accepted
 last-call-date-time: 2022-06-02T07:00:00Z
 created: 2022-05-19
@@ -47,7 +47,7 @@ A JSON-RPC relay will make calls to both consensus nodes and mirror nodes, some 
 
 ### Connects to Consensus and Mirror Nodes
 
-The JSON-RPC relay will connect to either consensus or mirror nodes depending on the requirements of the JSON-RPC calls. Queries will be performed against the mirror nodes or consensus nodes depending on data availability, while transactions affecting state will be performed against the consensus nodes, just as they would be for the SDK. 
+The JSON-RPC relay will connect to either consensus or mirror nodes depending on the requirements of the JSON-RPC calls. Queries will be performed against the mirror nodes or consensus nodes depending on data availability, while transactions affecting state will be performed against the consensus nodes, just as they would be for the SDK.
 
 ![JSON-RPC Relay Diagrams.png](../assets/hip-482/JSON-RPC Relay Diagrams.png)
 
@@ -773,6 +773,21 @@ Implementation:
 
 The JSON-RPC relay will return a static response.
 
+#### **eth_maxPriorityFeePerGas**
+
+Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block.
+
+Parameters:
+
+- None
+
+Result:
+
+- `Priority Fee` -  Hex value of the priority fee needed to be included in a block. Will always return `0x0`.
+
+Implementation:
+
+The JSON-RPC relay will return a static response.
 
 #### **eth_mining**
 
@@ -1023,7 +1038,7 @@ The JSON-RPC relay will return an error response.
 
 #### **web3_client_version**
 
-We return the JSON-RPC relay version number. 
+We return the JSON-RPC relay version number.
 
 Parameters:
 


### PR DESCRIPTION
Signed-off-by: Maksim Dimitrov <dimitrov.maksim@gmail.com>

**Description**:
This PR updates HIP-482 after `eth_maxPriotityFeePerGas` was added to the relay by https://github.com/hashgraph/hedera-json-rpc-relay/pull/595.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/586

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
