### PR TITLE
Update HIP-573 documentation to add all_collectors_are_exempt details

### DIFF
--- a/HIP/hip-573.md
+++ b/HIP/hip-573.md
@@ -69,7 +69,24 @@ check if the potential payer is a collector for the token type of that custom fe
 
 The mirror node is updated to add the new `all_collectors_are_exempt` field to the CustomFee.
 The new field is a `boolean` with a default value of `false` and cannot be null.
-This information will then be made available via the `/api/v1/tokens/{tokenId}` REST API.
+This information is available via the `/api/v1/tokens/{tokenId}` REST API.
+- Example: The other fields have been omitted for brevity
+```
+{
+    "custom_fees":{
+        "created_timestamp":"1665581996.952930663",
+        "fixed_fees":[
+           {
+            "amount":20,
+            "denominating_token_id":"0.0.48597542",
+            "collector_account_id":"0.0.48597559",
+            "all_collectors_are_exempt":true
+           }
+        ]
+    }
+    ....
+}
+```
 
 ## Backwards Compatibility
 

--- a/HIP/hip-573.md
+++ b/HIP/hip-573.md
@@ -65,6 +65,11 @@ The network needs to include the new `all_collectors_are_exempt` field in state 
 specification; and when deciding whether to assess a custom fee with `all_collectors_are_exempt = true`, needs to 
 check if the potential payer is a collector for the token type of that custom fee.
 
+### Mirror Node
+
+The mirror node is updated to add the new `all_collectors_are_exempt` field to the CustomFee in V1 and V2.
+This information will then be made available via new and existing REST APIs.
+
 ## Backwards Compatibility
 
 This HIP does not propose any breaking changes. All existing custom fees will be unchanged. Any unchanged 

--- a/HIP/hip-573.md
+++ b/HIP/hip-573.md
@@ -68,7 +68,8 @@ check if the potential payer is a collector for the token type of that custom fe
 ### Mirror Node
 
 The mirror node is updated to add the new `all_collectors_are_exempt` field to the CustomFee in V1 and V2.
-This information will then be made available via new and existing REST APIs.
+The new field is a `boolean` with a default value of `false` and cannot be null.
+This information will then be made available via the TokenInfo REST API.
 
 ## Backwards Compatibility
 

--- a/HIP/hip-573.md
+++ b/HIP/hip-573.md
@@ -67,7 +67,7 @@ check if the potential payer is a collector for the token type of that custom fe
 
 ### Mirror Node
 
-The mirror node is updated to add the new `all_collectors_are_exempt` field to the CustomFee in V1 and V2.
+The mirror node is updated to add the new `all_collectors_are_exempt` field to the CustomFee.
 The new field is a `boolean` with a default value of `false` and cannot be null.
 This information will then be made available via the TokenInfo REST API.
 

--- a/HIP/hip-573.md
+++ b/HIP/hip-573.md
@@ -69,7 +69,7 @@ check if the potential payer is a collector for the token type of that custom fe
 
 The mirror node is updated to add the new `all_collectors_are_exempt` field to the CustomFee.
 The new field is a `boolean` with a default value of `false` and cannot be null.
-This information will then be made available via the TokenInfo REST API.
+This information will then be made available via the `/api/v1/tokens/{tokenId}` REST API.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
**Description**:

As part of HIP-573 Blanket exemptions for custom fee collectors a new fields bool all_collectors_are_exempt was added to CustomFee in mirror node.
The HIP documentation for this needs to be updated.

This PR modifies
* Add Mirror node information to HIP-573 documentation


**Related issue(s)**:

Fixes # https://github.com/hashgraph/hedera-mirror-node/issues/4648

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
