### PR TITLE
Hip412 - Update Display Type

### DIFF
--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -10,7 +10,7 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discuss
 replaces: 10
 last-call-date-time: 2022-04-15T07:00:00Z
 created: 2022-04-01
-updated: 2022-04-27, 2022-09-20
+updated: 2022-04-27, 2022-09-20, 2022-10-24
 ---
 
 ## Abstract

--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -287,6 +287,7 @@ The standard also allows for localization. Each locale links to another metadata
 		},
 		{
 			"trait_type": "hasPipe",
+			"display_type": "boolean",
 			"value": true
 		},
 		{
@@ -332,6 +333,7 @@ Here's a clarification for the most important fields for the `HIP412@1.0.0` form
 (Optional) Indicates how the trait value should be displayed. Possible display types (but other types are allowed):
 
 - `text` (**default value representation**)
+- `boolean` (for boolean-based values -> It's recommended to start the trait naming with `is` or `has` e.g. `isAlive: true` or `hasPipe: true`)
 - `percentage` (for integer or number values)
 - `boost` (for integer or number values)
 - `datetime` (for a number which represents the unix timestamp in seconds)


### PR DESCRIPTION
**Description**:
To make it easier to parse NFT metadata following HIP412@1.0.0 format, include a `display_type` named `boolean` for parsing boolean values (true/false). Added a naming convention (is/has) recommendation.