### PR TITLE
Update reference implementation version for HIP412

### DIFF
--- a/HIP/hip-412.md
+++ b/HIP/hip-412.md
@@ -10,7 +10,7 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discuss
 replaces: 10
 last-call-date-time: 2022-04-15T07:00:00Z
 created: 2022-04-01
-updated: 2022-04-27, 2022-09-20, 2022-10-24
+updated: 2022-04-27, 2022-09-20, 2022-10-24, 2023-01-20
 ---
 
 ## Abstract
@@ -172,7 +172,7 @@ This allows NFT creators, communities and platforms to explicitly define the sch
 
 To reduce errors, "format" should be lower-case. For robustness, galleries and viewers should interpret format in a case-insensitive way to account for mistakes.
 
-The recommended schema for Hedera NFTs is `HIP412@1.0.0`. You can find the reference implementation for the `HIP412@1.0.0` standard here: https://nftstorage.link/ipfs/bafkreid2hxgyhhwtgkrzouwx4tk7kczhs6riydhpvisqq7pxofrllyftku or via this IPFS CID `ipfs://bafkreid2hxgyhhwtgkrzouwx4tk7kczhs6riydhpvisqq7pxofrllyftku`. This standard can evolve. Semantic versioning has been applied to the standard. The first version of the standard is represented by `HIP412@1.0.0`.
+The recommended schema for Hedera NFTs is `HIP412@2.0.0`. You can find the reference implementation for the `HIP412@2.0.0` standard here: https://nftstorage.link/ipfs/bafkreidcsqzr5su356thecwuyzrhsgekfdsqzuyuqxtsu4vh7oc34iv5oy or via this IPFS CID `ipfs://bafkreidcsqzr5su356thecwuyzrhsgekfdsqzuyuqxtsu4vh7oc34iv5oy`. This standard can evolve. Semantic versioning has been applied to the standard. The second version of the standard is represented by `HIP412@2.0.0`. Version `HIP412@1.0.0` refers to [HIP10](https://hips.hedera.com/hip/hip-10) which got replaced by HIP412.
 
 #### properties
 
@@ -238,9 +238,11 @@ Note that mime types for directories are not uniformly defined. Some IPFS CIDs p
 
 ## Reference Implementation
 
-### Default Schema: Collectibe Hedera NFTs (format: "HIP412@1.0.0")
+### Default Schema: Collectibe Hedera NFTs (format: "HIP412@2.0.0")
 
 This is a **recommended reference implementation for collectible Hedera NFTs**. The `HIP412` standard has been designed to be used by all NFT tooling (wallets, explorers) and be mostly compatible with other existing standards. 
+
+Version `HIP412@2.0.0` refers to the current, updated version for collectible Hedera NFTs while version `HIP412@1.0.0` refers to [HIP10](https://hips.hedera.com/hip/hip-10) which got replaced by HIP412.
 
 Here's an example of a full implementation of the metadata schema described in this `HIP412` specification for an image-based NFT. We are setting the image field to a URI and including the `checksum` field which represents a SHA-256 hash of the provided image. 
 
@@ -252,7 +254,7 @@ You can optionally define `attributes` to calculate rarity scores. We've added t
 
 The standard also allows for localization. Each locale links to another metadata file that contains the localized metadata and files. This allows for a clean metadata structure. Don't define another localization object for a localized metadata file to avoid infinite looping when parsing an NFT's metadata file.
 
-**A JSON schema can be found [here](https://nftstorage.link/ipfs/bafkreid2hxgyhhwtgkrzouwx4tk7kczhs6riydhpvisqq7pxofrllyftku) or via this IPFS CID `ipfs://bafkreid2hxgyhhwtgkrzouwx4tk7kczhs6riydhpvisqq7pxofrllyftku`. This is version v1.0.0, representing format `HIP412@1.0.0`.**
+**A JSON schema can be found [here](https://nftstorage.link/ipfs/bafkreidcsqzr5su356thecwuyzrhsgekfdsqzuyuqxtsu4vh7oc34iv5oy) or via this IPFS CID `ipfs://bafkreidcsqzr5su356thecwuyzrhsgekfdsqzuyuqxtsu4vh7oc34iv5oy`. This is version v2.0.0, representing format `HIP412@2.0.0`.**
 
 ```json
 {
@@ -263,7 +265,7 @@ The standard also allows for localization. Each locale links to another metadata
 	"image": "https://myserver.com/preview-image-nft-001.png",
 	"checksum": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	"type": "image/png",
-	"format": "HIP412@1.0.0",
+	"format": "HIP412@2.0.0",
 	"properties" : {
 		"external_url": "https://nft.com/mycollection/001"
 	},
@@ -316,7 +318,7 @@ The standard also allows for localization. Each locale links to another metadata
 }
 ```
 
-Here's a clarification for the most important fields for the `HIP412@1.0.0` format.
+Here's a clarification for the most important fields for the `HIP412@2.0.0` format.
 
 #### image
 
@@ -449,7 +451,7 @@ For more info see here: https://json-schema.org/
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"type": "object",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"additionalProperties": false,
 	"properties": {
 		"name": {
@@ -484,8 +486,8 @@ For more info see here: https://json-schema.org/
 		},
 		"format": {
 			"type": "string",
-			"default": "HIP412@1.0.0",
-			"description": "Name of the format or schema used by the NFT. For this schema representing Hedera Collectible NFts, set 'format' to 'HIP412@1.0.0'."
+			"default": "HIP412@2.0.0",
+			"description": "Name of the format or schema used by the NFT. For this schema representing Hedera Collectible NFts, set 'format' to 'HIP412@2.0.0'."
 		},
 		"properties": {
 			"type": "object",


### PR DESCRIPTION
**Description**:
Based on community feedback, NFT metadata specification v1.0.0 is reserved for HIP10, which has been replaced by HIP412. Hence, HIP412 should be referred to as HIP412 v2.0.0 metadata specification.

- Changed references
- Reuploaded specification to IPFS and updated references