### PR TITLE
Fix backwards compatibility clause

### DIFF
--- a/HIP/hip-657.md
+++ b/HIP/hip-657.md
@@ -123,7 +123,7 @@ Requirements: The NFT must exist on the Hedera network and should only be allowe
 ## Backwards Compatibility
 
 
-The addition of the METADATA key will not affect the functionality of existing NFTs on the Hedera Network because it will be available for use on new and existing NFTs.
+The addition of the METADATA key will not affect the functionality of existing NFTs on the Hedera Network because it will be available for use on new NFTs.
 
 ## Security Implications
 

--- a/HIP/hip-657.md
+++ b/HIP/hip-657.md
@@ -9,7 +9,7 @@ needs-council-approval: Yes
 status: Last Call
 created: 2023-01-04
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/607
-updated: 2023-01-21, 2023-01-24, 2023-02-03, 2023-02-15
+updated: 2023-01-21, 2023-01-24, 2023-02-03, 2023-02-15, 2023-02-22
 ---
 
 


### PR DESCRIPTION
**Description**:
The HIP-657 mentions that it affects both old and new NFTs while it will only apply to new NFTs.
