### PR TITLE
Identify community nodes in address book and related api

### DIFF
--- a/HIP/hip-0000.md
+++ b/HIP/hip-0000.md
@@ -8,6 +8,7 @@ category: Core
 needs-council-approval: Yes
 status: Draft
 created: 2023-03-01
+discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/691
 updated: 2023-03-07
 ---
 

--- a/HIP/hip-0000.md
+++ b/HIP/hip-0000.md
@@ -10,9 +10,6 @@ status: Draft
 created: 2023-03-01
 discussions-to: 
 updated: 2023-03-07
-requires: 
-replaces:
-superseded-by:
 ---
 
 ## Abstract

--- a/HIP/hip-0000.md
+++ b/HIP/hip-0000.md
@@ -1,3 +1,4 @@
+---
 hip: <HIP number (this is determined by the HIP editor)>
 title: Identify Community Nodes in Address Book and Related API
 author: Kim Rader <kim.rader@swirldslabs.com>
@@ -12,6 +13,7 @@ updated: <comma separated list of dates>
 requires: <HIP number(s)>
 replaces: <HIP number(s)>
 superseded-by: <HIP number(s)>
+---
 
 ## Abstract
 Add a flag to the address book to indicate whether a node belongs to a council member or a community member. Update related protobuf message and mirror node response objects.

--- a/HIP/hip-0000.md
+++ b/HIP/hip-0000.md
@@ -1,18 +1,18 @@
 ---
-hip: <HIP number (this is determined by the HIP editor)>
+hip: 0000
 title: Identify Community Nodes in Address Book and Related API
 author: Kim Rader <kim.rader@swirldslabs.com>
-working-group: Simi Hunjan <[simi@hedera.com](mailto:simi@hedera.com)>, Ali Katamjani <[ali@swirldslabs.com](mailto:ali@swirldslabs.com)>
+working-group: Simi Hunjan <simi@hedera.com>, Ali Katamjani <ali@swirldslabs.com>
 type: Standards Track
 category: Core
 needs-council-approval: Yes
 status: Draft
 created: 2023-03-01
-discussions-to: <URL pointing to the official discussion thread>
-updated: <comma separated list of dates>
-requires: <HIP number(s)>
-replaces: <HIP number(s)>
-superseded-by: <HIP number(s)>
+discussions-to: 
+updated: 2023-03-07
+requires: 
+replaces:
+superseded-by:
 ---
 
 ## Abstract

--- a/HIP/hip-0000.md
+++ b/HIP/hip-0000.md
@@ -8,7 +8,6 @@ category: Core
 needs-council-approval: Yes
 status: Draft
 created: 2023-03-01
-discussions-to: 
 updated: 2023-03-07
 ---
 

--- a/HIP/hip-0000.md
+++ b/HIP/hip-0000.md
@@ -1,0 +1,80 @@
+hip: <HIP number (this is determined by the HIP editor)>
+title: Identify Community Nodes in Address Book and Related API
+author: Kim Rader <kim.rader@swirldslabs.com>
+working-group: Simi Hunjan <[simi@hedera.com](mailto:simi@hedera.com)>, Ali Katamjani <[ali@swirldslabs.com](mailto:ali@swirldslabs.com)>
+type: Standards Track
+category: Core
+needs-council-approval: Yes
+status: Draft
+created: 2023-03-01
+discussions-to: <URL pointing to the official discussion thread>
+updated: <comma separated list of dates>
+requires: <HIP number(s)>
+replaces: <HIP number(s)>
+superseded-by: <HIP number(s)>
+
+## Abstract
+Add a flag to the address book to indicate whether a node belongs to a council member or a community member. Update related protobuf message and mirror node response objects.
+
+## Motivation
+As we begin onboarding node operators outside of council members as part of the community node project, there is a desire to be able to query using node Id whether a node is a community node or a council node.
+
+This information is important to users when choosing a node to stake to. This information can be made available in Hashscan and then partners can expose this data when offering staking to customers. In order to support this, Mirror Node Explorer needs to reliably know which node is council or community, so they can expose this data. Although this can be done manually, it will be extremely hard to maintain as we grow community nodes, therefore we will need to define a systematic path to query if a node is community node or not.
+
+Currently, council members have their accounts hardcoded. They need a way to rotate their account numbers. There is separate work going on to make that happen. Adding a community node flag is a required prerequisite.
+
+Application developers need a way to know which nodes are council nodes vs community nodes so that they can identify these two types of nodes in applications.
+
+## Rationale
+
+When Hedera begins allowing non-council members to run nodes, there will be more nodes coming online. This proposal seeks to provide a way to identify which nodes are council nodes and which are non-council (community) nodes.
+
+Currently, each node has an address book configuration file which ties IP addresses to nodes and accounts to nodes. We propose a small addition to the address book to add a new property to indicate whether a given node is a council node or a community node. The information can then be read by outside applications via a small change to the mirror node API.
+
+## User stories
+
+- As an application developer, I need a reliable way to know which nodes are council nodes vs. community nodes so that I can appropriately identify them in my application.
+- As a developer for an application which supports staking, I want to be able to show my customers whether a node they are choosing to stake to is council or community node.
+    - Users might trust council operated nodes over community hosted nodes
+    - Today, we only have council nodes in the nodes page in the explorer
+    - After community nodes are added there is not an immediate way to tell the node operator type (community vs. council)
+
+## Specification
+
+Node addresses are configured in a JSON-formatted network file defined by the NodeAddressBook protobuf. The proposal is to add a new optional boolean property `communityNode` as a new property of the `nodeAddress` object in the address book file. If true, the flag indicates that this node belongs to a community member. If false, the flag indicates that this node belongs to a council member. If omitted the property defaults to false, ensuring backwards compatibility.
+
+The `[nodeAddress](https://github.com/hashgraph/hedera-protobufs/blob/main/services/basic_types.proto#L1330)` protobuf definition requires a new property `communityNode` to transmit this information.
+
+The mirrornode REST API will also expose this datum. The /network/nodes endpoint currently returns an array of `nodes` objects. A new boolean `communityNode` will be added to the `nodes` response object.
+
+## Backwards Compatibility
+
+If not present in the address book configuration, the `communityNode` property defaults to false. This ensures full backwards compatibility.
+
+## Security Implications
+
+No security implications noted.
+
+## How to Teach This
+
+- Hedera protobuf documentation
+- Hedera Mirror Node documentation - description and code examples of queries in the REST API documentation
+
+## Rejected Ideas
+
+If community node operator node account IDs are not part of the Hedera system accounts (entities under `0.0.1000`) then the application could say all council nodes are node account IDs under `0.0.1000` and all node account IDs greater than 1000 are community nodes.
+
+This idea was discussed but rejected because there have been requests by council members to move to new account numbers above 0.0.1000 and not one of the accounts in the privileged range, making this idea not a viable long term solution.
+
+## Open Issues
+
+None.
+
+## References
+
+- [https://github.com/hashgraph/hedera-protobufs/blob/main/services/basic_types.proto#L1330](https://github.com/hashgraph/hedera-protobufs/blob/main/services/basic_types.proto#L1330)
+- [https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/network/getNetworkNodes](https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/network/getNetworkNodes)
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](*../LICENSE*) or (https://www.apache.org/licenses/LICENSE-2.0)

--- a/HIP/hip-690.md
+++ b/HIP/hip-690.md
@@ -1,12 +1,12 @@
 ---
-hip: 0000
+hip: 690
 title: Identify Community Nodes in Address Book and Related API
 author: Kim Rader <kim.rader@swirldslabs.com>
 working-group: Simi Hunjan <simi@hedera.com>, Ali Katamjani <ali@swirldslabs.com>
 type: Standards Track
 category: Core
 needs-council-approval: Yes
-status: Draft
+status: Last Call
 created: 2023-03-01
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/691
 updated: 2023-03-07


### PR DESCRIPTION
Initial draft of a HIP to add a flag to the address book to indicate whether a node belongs to a council member or a community member. Also update related protobuf message and mirror node response objects.
