### PR TITLE
Update hip-690.md to an enum instead of boolean flag

### DIFF
--- a/HIP/hip-690.md
+++ b/HIP/hip-690.md
@@ -41,7 +41,7 @@ Currently, each node has an address book configuration file which ties IP addres
 
 ## Specification
 
-Node addresses are configured in a JSON-formatted network file defined by the NodeAddressBook protobuf. The proposal is to add a new optional enum property `nodeType` as a new property of the `nodeAddress` object in the address book file. If the value of the type is `community`, this indicates that this node belongs to a community member. If the value of the type is `council`, this indicates that this node belongs to a council member. If omitted the property defaults to false, ensuring backwards compatibility.
+Node addresses are configured in a JSON-formatted network file defined by the NodeAddressBook protobuf. The proposal is to add a new optional enum property `nodeType` as a new property of the `nodeAddress` object in the address book file. If the value of the type is `community`, this indicates that this node belongs to a community member. If the value of the type is `council`, this indicates that this node belongs to a council member. If omitted the property defaults to `council`, ensuring backwards compatibility.
 
 The [nodeAddress protobuf definition](https://github.com/hashgraph/hedera-protobufs/blob/main/services/basic_types.proto#L1330) requires a new property `communityNode` to transmit this information.
 

--- a/HIP/hip-690.md
+++ b/HIP/hip-690.md
@@ -7,6 +7,7 @@ type: Standards Track
 category: Core
 needs-council-approval: Yes
 status: Last Call
+last-call-date-time: 2023-03-27T07:00:00Z
 created: 2023-03-01
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/691
 updated: 2023-03-13

--- a/HIP/hip-690.md
+++ b/HIP/hip-690.md
@@ -13,7 +13,7 @@ updated: 2023-03-13
 ---
 
 ## Abstract
-Add a flag to the address book to indicate whether a node belongs to a council member or a community member. Update related protobuf message and mirror node response objects.
+Add an enum to the address book to indicate whether a node belongs to a council member or a community member. Update related protobuf message and mirror node response objects.
 
 ## Motivation
 As we begin onboarding node operators outside of council members as part of the community node project, there is a desire to be able to query using node Id whether a node is a community node or a council node.
@@ -40,7 +40,7 @@ Currently, each node has an address book configuration file which ties IP addres
 
 ## Specification
 
-Node addresses are configured in a JSON-formatted network file defined by the NodeAddressBook protobuf. The proposal is to add a new optional boolean property `communityNode` as a new property of the `nodeAddress` object in the address book file. If true, the flag indicates that this node belongs to a community member. If false, the flag indicates that this node belongs to a council member. If omitted the property defaults to false, ensuring backwards compatibility.
+Node addresses are configured in a JSON-formatted network file defined by the NodeAddressBook protobuf. The proposal is to add a new optional enum property `nodeType` as a new property of the `nodeAddress` object in the address book file. If the value of the type is `community`, this indicates that this node belongs to a community member. If the value of the type is `council`, this indicates that this node belongs to a council member. If omitted the property defaults to false, ensuring backwards compatibility.
 
 The [nodeAddress protobuf definition](https://github.com/hashgraph/hedera-protobufs/blob/main/services/basic_types.proto#L1330) requires a new property `communityNode` to transmit this information.
 
@@ -48,7 +48,7 @@ The mirrornode REST API will also expose this datum. The /network/nodes endpoint
 
 ## Backwards Compatibility
 
-If not present in the address book configuration, the `communityNode` property defaults to false. This ensures full backwards compatibility.
+If not present in the address book configuration, the `nodeType` property defaults to `council`. This ensures full backwards compatibility.
 
 ## Security Implications
 

--- a/HIP/hip-690.md
+++ b/HIP/hip-690.md
@@ -10,7 +10,7 @@ status: Last Call
 last-call-date-time: 2023-03-27T07:00:00Z
 created: 2023-03-01
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/691
-updated: 2023-03-13
+updated: 2023-03-15
 ---
 
 ## Abstract
@@ -43,9 +43,9 @@ Currently, each node has an address book configuration file which ties IP addres
 
 Node addresses are configured in a JSON-formatted network file defined by the NodeAddressBook protobuf. The proposal is to add a new optional enum property `nodeType` as a new property of the `nodeAddress` object in the address book file. If the value of the type is `community`, this indicates that this node belongs to a community member. If the value of the type is `council`, this indicates that this node belongs to a council member. If omitted the property defaults to `council`, ensuring backwards compatibility.
 
-The [nodeAddress protobuf definition](https://github.com/hashgraph/hedera-protobufs/blob/main/services/basic_types.proto#L1330) requires a new property `communityNode` to transmit this information.
+The [nodeAddress protobuf definition](https://github.com/hashgraph/hedera-protobufs/blob/main/services/basic_types.proto#L1330) requires a new property `nodeType` to transmit this information.
 
-The mirrornode REST API will also expose this datum. The /network/nodes endpoint currently returns an array of `nodes` objects. A new boolean `communityNode` will be added to the `nodes` response object.
+The mirrornode REST API will also expose this datum. The /network/nodes endpoint currently returns an array of `nodes` objects. A new enum `nodeType` will be added to the `nodes` response object.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
**Description**:
This PR modifies `hip-690.md` to refer to an enum instead of a boolean flag for identifying node types. With the anticipation of anonymous nodes, using an enum will also allow us to capture that type.

- enum is called `nodeType`
- current values are `community` and `council`, with the default being `council`

