### PR TITLE
Update hip-406.md

### DIFF
--- a/HIP/hip-406.md
+++ b/HIP/hip-406.md
@@ -10,7 +10,7 @@ last-call-date-time: 2022-06-02T07:00:00Z
 release: v0.27.0
 created: 2022-03-27
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/408
-updated: 2022-04-20, 2022-05-25, 2022-06-02, 2022-11-14
+updated: 2022-04-20, 2022-05-25, 2022-06-02, 2022-11-14, 2023-03-25
 ---
 
 ## Abstract
@@ -106,6 +106,8 @@ Alice stakes her account containing 1 hbar to a node and then loses her key. Eve
 ### 18. The total stake to a node exceeds the max
 
 A node has a max stake of 30, but Alice stakes 100 to it and Bob stakes 200 to it, so the total stake is 300. Only 30 of that 300 will count, which is one tenth. So Alice earns rewards as if she had staked only 10, and Bob earns rewards as if he had staked only 20, and the node gains weight in consensus as if only 30 had been staked to it. The excess staking is ignored. (These numbers are unrealistic, but are just chosen for this example to make the math simple).
+
+A node has a max stake of 30, but Alice stakes 100 to it, Bob stakes 200 to it, and Carol stakes 50 to it, without claiming rewards. The total stake is now 350. Since Carol is not claiming rewards, the proportional allocation of rewards between Alice and Bob remains the same as in the previous scenario. However, the node's weight in consensus will still be calculated as if only 30 had been staked to it. The excess coins are not rewarded and do not affect consensus weight.
 
 ### 19. Accounts stake non-whole number of hbars 
 
@@ -342,7 +344,7 @@ The following new settings will be added to the system, and set by transactions 
 - `StakingRewardRate` - the total tinybars earned as staking reward during each staking period (example: 100\_000\_000L * 1\_000\_000\_000 / 365 to emit rewards at a total rate of one billion hbars per year)
 - `StakingStartThreshold` - Staking rewards are earned starting when `0.0.800` reaches this balance (example: 1 billion)
 - `MinStake` (per node) - the minimum amount that must be staked to that node, in order for the node to participate in consensus
-- `MaxStake` (per node) - the maximum amount of the stake to that node that will count (any amount staked above this is ignored for purpose of consensus weight and for staking rewards)
+- `MaxStake` (per node) - the maximum amount of the stake to that node that will count (the excess coins are not rewarded and do not affect consensus weight)
 - `StakingRewardFeeFraction` - the fraction of each transaction fee (excluding node fee) that goes to the staking reward account `0.0.800`.
 - `NodeRewardFeeFraction` - the fraction of each transaction fee (excluding node fee) that goes to the node reward account `0.0.801`. The remaining fraction `(1 - StakingRewardFeeFraction - NodeRewardFeeFraction)` goes to the treasury account `0.0.98`. Therefore, the sum of the two fractions must be between 0 and 1, inclusive.
 - `stakingPeriodsStored` - the number of staking periods for which the reward is stored for each node. For simplicity, this was described as `365` throughout this HIP, but should actually be an adjustable setting. NOTE: this should always be set to be an equal or longer period than the max expiration period for any entity. That will ensure that auto-renew guarantees that all earned rewards are eventually paid, and none are ever lost. 

--- a/HIP/hip-406.md
+++ b/HIP/hip-406.md
@@ -10,7 +10,7 @@ last-call-date-time: 2022-06-02T07:00:00Z
 release: v0.27.0
 created: 2022-03-27
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/408
-updated: 2022-04-20, 2022-05-25, 2022-06-02, 2022-11-14, 2023-03-25
+updated: 2022-04-20, 2022-05-25, 2022-06-02, 2022-11-14, 2023-03-27
 ---
 
 ## Abstract

--- a/HIP/hip-406.md
+++ b/HIP/hip-406.md
@@ -107,7 +107,7 @@ Alice stakes her account containing 1 hbar to a node and then loses her key. Eve
 
 A node has a max stake of 30, but Alice stakes 100 to it and Bob stakes 200 to it, so the total stake is 300. Only 30 of that 300 will count, which is one tenth. So Alice earns rewards as if she had staked only 10, and Bob earns rewards as if he had staked only 20, and the node gains weight in consensus as if only 30 had been staked to it. The excess staking is ignored. (These numbers are unrealistic, but are just chosen for this example to make the math simple).
 
-A node has a max stake of 30, but Alice stakes 100 to it, Bob stakes 200 to it, and Carol stakes 50 to it, without claiming rewards. The total stake is now 350. Since Carol is not claiming rewards, the proportional allocation of rewards between Alice and Bob remains the same as in the previous scenario. However, the node's weight in consensus will still be calculated as if only 30 had been staked to it. The excess coins are not rewarded and do not affect consensus weight.
+A node has a max stake of 30, but Alice stakes 100 to it, Bob stakes 200 to it (both claiming rewards), and Carol stakes 50 to it (without claiming rewards). The total stake is now 350. Since Carol is not claiming rewards, the proportional allocation of rewards between Alice and Bob remains the same as in the previous scenario. However, the node's weight in consensus will still be calculated as if only 30 had been staked to it. The excess coins are not rewarded and do not affect consensus weight.
 
 ### 19. Accounts stake non-whole number of hbars 
 


### PR DESCRIPTION
This PR adds clarification for staking rewards and consensus weight explanations by:

- Adding a new scenario with Carol, who stakes without claiming a reward, to better illustrate reward distribution.

- Replacing the term "ignored" with a clearer explanation that excess coins are not rewarded and don't affect consensus weight.

These updates enhance the clarity of the documentation.