### PR TITLE
Get modified files from curl request rather than git diff to validate hips

### DIFF
--- a/.github/workflows/validateHeaders.yml
+++ b/.github/workflows/validateHeaders.yml
@@ -14,16 +14,26 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: "12.x"
+
+      - name: Install jq
+        run: sudo apt-get install jq
 
       - name: Validate HIPs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            arrayOfFiles=()
-            while IFS= read -r; do
-              arrayOfFiles+=("${REPLY}")
-            done < <(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --name-only | grep .md)
-            for i in "${arrayOfFiles[@]}"
-            do
-                node "${{ github.workspace }}/scripts/validateHIP.js" "${{ github.workspace }}/HIP/"$(basename "$i")""
-                echo 
-            done
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+          PR_DATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/files")
+          MD_FILES=$(echo "$PR_DATA" | jq -r '.[] | select(.filename | test(".md$")) | .filename')
+
+          for FILE in $MD_FILES; do
+            FULL_PATH="${{ github.workspace }}/$FILE"
+            if [[ -f "$FULL_PATH" ]]; then
+              node "${{ github.workspace }}/scripts/validateHIP.js" "$FULL_PATH"
+            else
+              echo "No file found for $FILE"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
This logic only checks files that were changed in the PR itself and removes the logic that is getting the file names to validate from a git diff command. It fetches the PR data using GitHub's API and extracts the file names from there. By doing this, we resolve any branches or forks being out of sync so the correct hips are always validated