### PR TITLE
docs: readme prereqs and server cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![](https://img.shields.io/badge/view-published-blue)](https://hips.hedera.com)
 
 ## Submit a HIP
+
 1. Fork this repository
 2. Fill out this template: [hip template](hip-0000-template.md)
 3. Create a pull request against hashgraph/hedera-improvement-proposal main
@@ -41,7 +42,12 @@ Each HIP should only be one single key proposal and/or idea. The idea should be 
 4. Reevaluate your proposal to ensure sure the idea is applicable to the entire community and not just to one particular author, application, project, or protocol.
 
 ## Local Jekyll Site
-Prereq - make sure you have bundler for Ruby
+
+Pre-requisites:
+
+- `ruby`: `2.7.8p225`
+- `gem`: `3.4.10`
+- `bundler`: `1.17.3`
 
 You can run a local version of the HIPs dashboard site:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can run a local version of the HIPs dashboard site:
 
 ```shell
 bundle install
-jekyll serve --livereload
+bundle exec jekyll serve --livereload
 ```
 
 The site will be available on `http://localhost:4000`.


### PR DESCRIPTION
**Description**:

This PR modifies the README in order to support easier local set up:

* prefix jekyll command with 'bundle exec' as we should not assume that the jekyll gem has been installed globally as well
* add specific ruby, gem, and bundler version numbers (known working combination) to readme

This is needed because (1) default installations via `brew` etc are too recent, and (2) default installation version on Mac OSX (even on Ventura) are too old.

**Related issue(s)**:

NIL

**Notes for reviewer**:

NIL

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.) --> N/A
