### PR TITLE
fix: discussion to template

### DIFF
--- a/_layouts/hip.html
+++ b/_layouts/hip.html
@@ -42,10 +42,10 @@ layout: default
       <td>{{ page.working-group }}</td>
     </tr>
     {% endif %}
-    {% if page["discussions-to"] != undefined %}
+    {% if page.discussions-to != undefined %}
     <tr>
       <th>Discussions-To</th>
-      <td><a href="{{ page[" discussions-to"] | uri_escape }}">{{ page["discussions-to"] | xml_escape }}</a></td>
+      <td><a href="{{ page.discussions-to | uri_escape }}">{{ page.discussions-to | xml_escape }}</a></td>
     </tr>
     {% endif %}
     <tr>


### PR DESCRIPTION
**Description**:

This PR modifies `_layouts/hip.html` in order to support a working hyperlink for the 'discussions-to' field.
* used `page.discussions-to` instead of `page[" discussions-to"]` the space character as a prefix in the property name was likely culprit
* syntax consistent with `page.needs-council-approval` within same template


**Related issue(s)**:

NIL

**Notes for reviewer**:

- Check out an example HIP: https://hips.hedera.com/hip/hip-415
- "Discussions-To" has `https://github.com/hashgraph/hedera-improvement-proposal/discussions/434` as the hyperlink's text, but `https://hips.hedera.com/hip/hip-415` as the hyperlink's URL for some reason


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
    - Note: Tested manually, no programmatic tests added.
    - ~~Needs verification on actual deployment, as was unable to reproduce the rendering error locally.~~ --> Verified that it works with netlify deployment preview: https://deploy-preview-744--hedera-hips.netlify.app/hip/hip-415
