### PR TITLE
Update HIP-540 with new remove and change behavior for token keys

### DIFF
--- a/HIP/hip-540.md
+++ b/HIP/hip-540.md
@@ -1,6 +1,6 @@
 ---
 hip: 540
-title: Remove Existing Keys From A Token Or Contract
+title: Change Or Remove Existing Keys From A Token
 author: Cooper Kunz (@cooper_kunz), Justyn Spooner <justyn@dovu.io>
 working-group: Cooper Kunz (@cooper_kunz), Justyn Spooner (@justynjj), Jason Fabritz (@bugbytesinc), Michiel Mulders (@michielmulders), Ashe Oro (@Ashe-Oro)
 type: Standards Track

--- a/HIP/hip-540.md
+++ b/HIP/hip-540.md
@@ -9,7 +9,7 @@ needs-council-approval: Yes
 status: Last Call
 created: 2022-08-05
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/522
-updated: 2022-08-05, 2022-08-12, 2022-08-16, 2022-09-06, 2022-09-20, 2022-12-19, 2023-01-18, 2023-06-14
+updated: 2022-08-05, 2022-08-12, 2022-08-16, 2022-09-06, 2022-09-20, 2022-12-19, 2023-01-18, 2023-06-15
 ---
 
 ## Abstract

--- a/HIP/hip-540.md
+++ b/HIP/hip-540.md
@@ -2,29 +2,29 @@
 hip: 540
 title: Remove Existing Keys From A Token Or Contract
 author: Cooper Kunz (@cooper_kunz), Justyn Spooner <justyn@dovu.io>
-working-group: Cooper Kunz (@cooper_kunz), Justyn Spooner (@justynjj), Jason Fabritz (@bugbytesinc)
+working-group: Cooper Kunz (@cooper_kunz), Justyn Spooner (@justynjj), Jason Fabritz (@bugbytesinc), Michiel Mulders (@michielmulders), Ashe Oro (@Ashe-Oro)
 type: Standards Track
 category: Service
 needs-council-approval: Yes
-status: Review
+status: Last Call
 created: 2022-08-05
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/522
-updated: 2022-08-05, 2022-08-12, 2022-08-16, 2022-09-06, 2022-09-20, 2022-12-19, 2023-01-18
+updated: 2022-08-05, 2022-08-12, 2022-08-16, 2022-09-06, 2022-09-20, 2022-12-19, 2023-01-18, 2023-06-14
 ---
 
 ## Abstract
 
-All entities across Hedera have opt-in administrative keys. Currently, the Consensus Service and File service allow these keys to be removed (making the entities immutable). However the Contract and Token Services do not provide such a feature consistently. We should enable existing administrative keys for these entities to be able to sign an update transaction that permanently removes any privileged key (Admin, Wipe, KYC, Freeze, Pause, Supply, Fee Schedule) from the entity.
+All entities across Hedera have opt-in administrative keys. Currently, the Consensus Service and File service allow these keys to be removed (making the entities immutable). However the Hedera Token Service does not provide such a feature consistently. We should enable existing administrative keys for tokens created with the Hedera Token Service to be able to sign an update transaction that changes or permanently removes any privileged key (Admin, Wipe, KYC, Freeze, Pause, Supply, Fee Schedule) from the entity.
 
 ## Motivation
 
-Many NFT projects require that their token remains immutable yet some project owners have unknowingly created NFTs with keys such as Admin, Wipe, Freeze and Pause set which undermines this assumption.
+Many NFT projects require that their token remains immutable yet some project owners have unknowingly created NFTs with keys such as Admin, Wipe, Freeze and Pause keys set, which undermines this assumption.
 
 The majority of collectors will also be unaware of the implications of having these keys set on the NFTs they have purchased.
 
 For example, an NFT with a [Wipe Key](https://docs.hedera.com/guides/docs/sdks/tokens/wipe-a-token) set poses a risk to the owner that the NFT could at any point be burned even though it's not in the treasury account.
 
-Right now there is no way to remove keys (Admin, Wipe, KYC, Freeze, Pause, Supply, Fee Schedule) from a Token. They can only be updated.
+Right now there is no way to remove keys (Admin, Wipe, KYC, Freeze, Pause, Supply, Fee Schedule) from a Token. They can only be changed when the [TokenUpdateTransaction](https://docs.hedera.com/hedera/sdks-and-apis/sdks/readme-1/update-a-token) is signed by the admin key.
 
 ## Rationale
 
@@ -38,9 +38,9 @@ Ashe Oro raised the following question in this [tweet](https://twitter.com/Ashe_
 
 @TMCC_Patches responded with these stats:
 
-> w/ wipe or freeze keys: 66,914
+> With wipe or freeze keys: 66,914
 >
-> w/o 707,178
+> Without: 707,178
 
 A large proportion of the creators of those 66,914 NFTs are likely unaware of the implications those keys have on their collection.
 
@@ -51,15 +51,15 @@ These conversations have led to this HIP as right now there is no way for a crea
 DPub raises a requirement for this on Discord [here](https://discord.com/channels/373889138199494658/768621337865486347/943265960704479292)
 
 > ...can you remove the admin key? Use case - is setup the token, mint - make sure it is all good - if not - burn. if good - make immutable - remove adminkey and supplykey
-> i thought we were able to - but testing - doesn't look like there is a way to set to null. setAdminKey() doesn't do anything. We could create a throwaway adminkey, but people might not believe that
+> I thought we were able to - but testing - doesn't look like there is a way to set to null. setAdminKey() doesn't do anything. We could create a throwaway adminkey, but people might not believe that.
 
 Topachi from Hbar Suite also raises a requirement for this feature in [Discord](https://discord.com/channels/373889138199494658/768621337865486347/989981510125879316)
 
 > Could you guys please do this? Because in the future we might need to remove some keys if the community wishes, and it would be much easier with a permanent token update instead of creating a v2 of our token.
 
-The only way to "address" this currently is to either:
+The only way to address this currently is to either:
 
-1. Mint a brand new collection without the admin/wipe/freeze keys set and airdrop to everyone who had the v1 version
+1. Mint a brand new collection without the admin/wipe/freeze keys set and airdrop to everyone who had the v1 version.
 2. Generate a bad key to replace the existing keys in the token as suggested in the [Hedera Discord token-service channel](https://discord.com/channels/373889138199494658/768621337865486347/990019307897520169)
    > There is, however, a quick-and-dirty way to make an NFT collection un-wipeable:
    >
@@ -69,69 +69,60 @@ The only way to "address" this currently is to either:
 
 Neither of these approaches is ideal and could easily be solved by allowing the keys to be wiped as part of a `TokenUpdateTransaction` call.
 
+## Language
+
+First, let's address important language to set a clear distinction between "removed" and "invalid".
+
+- "Lower privilege key" refers to all keys you can set for a token except for the admin key, which is a high privilege key. In other words, the KYC, freeze, pause, wipe, supply, and fee schedule keys are considered low privilege keys.
+- "Removed" refers to not setting a key or setting it to "no key". If a key is absent, the token is considered immutable for that key. For example, if the freeze-key is absent when the token is created, then even the admin cannot create a freeze-key later on.
+- "Invalid" refers to an invalid key, such as an all-zero key (the key is present, but no private key corresponds to it like `0x0000000000000000000000000000000000000000`). There’s nothing magical about the all-zero key except we believe that it is difficult to find a private key that maps to an all-zero public key. So we recommend using all-zeros for all invalid keys.
+
 ## User stories
 
-- As a creator I want to remove the Wipe Key on my existing NFT collection so that collectors can be assured their NFT can't be removed from their account.
+- As a creator I want to remove the Wipe Key using the Admin Key on my existing NFT collection so that collectors can be assured their NFT can't be removed from their account.
 - As a creator I want to remove the Admin Key on my existing NFT collection so that I can be sure my NFT is immutable.
 - As a creator I want the flexibility to remove keys as my project evolves. For example, I might start out with KYC as a requirement and later decide that it is not necessary.
-- As an NFT minting service I want to be able to mint an NFT collection on behalf of a creator using our private key and then update the treasury account to the creator's account whilst simultaneously removing the admin key so the creator ends up with an immutable NFT collection in their treasury account.
-- As an author of a smart contract that I am now happy is operating smoothly, I would like to remove the admin key
+- As an NFT minting service I want to be able to mint an NFT collection on behalf of a creator using our private key and then update the treasury account to the creator's account whilst simultaneously removing the Admin Key so the creator ends up with an immutable NFT collection in their treasury account.
+- As an NFT creator, I want to reduce the risk profile of my NFT Collection by using a lower privilege key to update itself to an invalid key (i.e. all-zeros key) without having to use the Admin Key.
 
 ## Specification
 
-1. Introduce a constant to represent an empty key. This will be used as part of the token and/or contract update calls to remove existing keys.
+1. Only the admin key should be able to remove itself or other keys.
+2. All keys can change themselves to another valid or invalid key (such as all-zeros).
 
-2. Update all other areas of the SDK that make use of an empty key to use this new constant for consistency.
+### Other Considerations
 
-We use the JS SDK for demonstration using the HTS token entity as an example. The same approaches could be take for the `ContractUpdateTransaction`.
+1. We should standardize the use of all-zeros key as an invalid key across all keys in Hedera.
+2. We will have to add a boolean flag in the update transaction about whether the system should check the validity of the updated key. Currently, we test the validity for all updates. With this boolean flag, the user will be able to tell the system to avoid checking of the validity of the updated key. The default value of the flag will maintain the current behavior of checking the validity.
 
-### Extend `TokenUpdateTransaction` to Support Removing Keys
-
-All these keys should be removable as part of a `TokenUpdateTransaction` if they are present on a Token:
-
-- Admin Key
-- Wipe Key
-- KYC Key
-- Freeze Key
-- Pause Key
-- Supply Key
-- Fee Schedule Key
-
-**An example `TokenUpdateTransaction` to remove all keys from a Token.**
+Here's a simple code example illustrating this boolean when updating a key to an invalid key.
 
 ```js
-let transaction = new TokenUpdateTransaction({
-  tokenId: "0.0.123456",
-  kycKey: Key.None,
-  freezeKey: Key.None,
-  pauseKey: Key.None,
-  wipeKey: Key.None,
-  supplyKey: Key.None,
-  feeScheduleKey: Key.None,
-  adminKey: Key.None,
-}).freezeWithClient(client);
-
-// Sign the transaction with the admin key
-const signTx = await transaction.sign(adminKey);
+const newSupplyKey = "0x0000000000000000000000000000000000000000";
+let tokenUpdateTx = await new TokenUpdateTransaction()
+    .setTokenId(tokenId)
+    // Interface (key: Key, shouldVerifyKey: boolean = true) 
+    // When set to false, the TokenUpdateTransaction won't check for the validity of the key
+    .setSupplyKey(newSupplyKey, false)
+    .freezeWith(client)
+    .sign(oldSupplyKey)
 ```
 
-**Key.None**
-We can’t use `null` as the value for these fields because behind the scenes protobuf removes them for optimisation. An empty KeyList could be used however, since this action can't be undone, we propose having a dedicated constant `Key.None`. The constant provides clearer intent which is crucial when dealing with a transaction that can't be reversed.
+### Flow Diagram
 
-**Requirements**
+There are a couple of flows to determine the immutability of a key:
 
-- If an empty KeyList is passed in, the SDK should throw an error to avoid accidental removal of keys.
-- The `TokenUpdateTransaction` should be able to remove any/all keys from a token if the key exists on the token.
-- If the Admin key is removed as part of the update transaction, then all other updates should happen first and the admin key removed last to avoid any `TOKEN_IS_IMMUTABLE` errors.
-- If a key doesn't exist on the token and a call is made to remove it then return a `TOKEN_HAS_NO_SUPPLY_KEY`, `TOKEN_HAS_NO_PAUSE_KEY` etc. This error response is the same as when trying to update a key that doesn't exist.
-- All transactions to remove a key must be signed with the admin key so if a token has no admin key, then any other keys present can't be removed.
-- When a key is removed, the token should appear as if it was created with no key set for that field. For example, if the admin key is removed, then the token should appear as if it was created with no admin key set.
+1. If a key is not set.
+2. If a lower-privilege key is set to all-zeros and no Admin Key is present.
+3. If a lower-privilege and Admin Key are set to all-zeros.
+
+![Flow Diagram Testing Immutability](https://user-images.githubusercontent.com/5784328/242635931-ff236217-72ad-4123-b496-c3fa9db3e555.png)
 
 ## Backwards Compatibility
 
-This change is fully backwards compatible & opt-in. Existing entities that have been created with administrative keys can continue operating as desired. Entities that have been created without administrative keys can continue operating as desired.
+This change is fully backward compatible & opt-in. Existing entities created with administrative keys can continue operating as desired. Entities that have been created without administrative keys can continue operating as desired.
 
-Existing services such as HCS allow you to remove keys using the empty KeyList. Making these services consistent with the proposal above would result in an error being returned. The proposal above uses a dedicated constant to remove keys which is more explicit and less error prone.
+In short, entities gain better administrative controls to manage their token.
 
 ## Security Implications
 
@@ -139,54 +130,13 @@ Generally with administrative keys there are security requirements about how to 
 
 ## How to Teach This
 
-The documentation for the [Token Service - Token Update](https://docs.hedera.com/guides/docs/sdks/tokens/update-a-token) would be updated to add examples on how to remove keys from a Token.
-
-## Reference Implementation
+The documentation for the [Token Service - Token Update](https://docs.hedera.com/guides/docs/sdks/tokens/update-a-token) would be updated to add examples on how to remove keys from a token.
 
 ## Rejected Ideas
 
-There was a discussion to introduce a dedicated method for removing keys. It opened up too many edge cases and since the solution proposed above solves the problem, it was decided to go with that approach.
+There was a discussion to introduce a dedicated method for removing keys. It opened up too many edge cases, and since the solution proposed above solves the problem, it was decided to go with that approach.
 
-Here was the second option:
-
-### Option 2. Dedicated Remove Key Action
-
-An alternative approach might be to have a dedicated transaction `RemoveKeysTransaction`.
-
-This would take 3 parameters
-`tokenId` - The token to update
-`removeKey` - An enum representing a key Key.Wipe, Key.Freeze etc
-`removeKeys` - An array of Key enums [Key.Pause, Key.FeeSchedule, Key.Admin]
-
-**An example of removing the wipe key from an NFT**
-
-```js
-const transaction = new RemoveKeysTransaction()
-  .setTokenId(tokenId)
-  .setRemoveKey(Key.Wipe)
-  .freezeWithClient(client);
-
-// Sign the transaction with the admin key
-const signTx = await transaction.sign(adminKey);
-```
-
-**An example of removing multiple keys from a Token**
-
-```js
-const transaction = new RemoveKeysTransaction()
-  .setTokenId(tokenId)
-  .setRemoveKeys([Key.Pause, Key.FeeSchedule, Key.Kyc])
-  .freezeWithClient(client);
-
-// Sign the transaction with the admin key
-const signPauseTx = await transaction.sign(adminKey);
-```
-
-## Open Issues
-
-Greg Scullard raises an important point on why an early decision was made to prevent the removal of keys. This should be discussed as part of this HIP review so everyone is clear how removing certain keys could affect the token.
-
-> Generally speaking, whenever a key is set on an entity, it cannot be removed (so the same applies to supply, freeze, etc... keys). This is an early design decision which makes sense for some keys, if you had a freeze key and frozen accounts, unsetting the key would mean these accounts would be frozen for ever, unless a check is made which could be costly in terms of performance… - Greg Scullard [Discord](https://discord.com/channels/373889138199494658/616725732650909710/935199340555800616)
+Another rejected approach is the ability to allow higher-privilege keys to change or remove themselves. However, this again opens up too many flows when, for instance, the admin key removes itself, and all lower-privilege keys become higher-privilege keys. Technically this is a sound proposal. However, it could be a better solution from a usability perspective.
 
 ## References
 

--- a/HIP/hip-540.md
+++ b/HIP/hip-540.md
@@ -7,9 +7,10 @@ type: Standards Track
 category: Service
 needs-council-approval: Yes
 status: Last Call
+last-call-date-time: 2022-07-03T07:00:00Z
 created: 2022-08-05
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/522
-updated: 2022-08-05, 2022-08-12, 2022-08-16, 2022-09-06, 2022-09-20, 2022-12-19, 2023-01-18, 2023-06-15
+updated: 2023-06-19
 ---
 
 ## Abstract

--- a/HIP/hip-540.md
+++ b/HIP/hip-540.md
@@ -2,7 +2,7 @@
 hip: 540
 title: Change Or Remove Existing Keys From A Token
 author: Cooper Kunz (@cooper_kunz), Justyn Spooner <justyn@dovu.io>
-working-group: Cooper Kunz (@cooper_kunz), Justyn Spooner (@justynjj), Jason Fabritz (@bugbytesinc), Michiel Mulders (@michielmulders), Ashe Oro (@Ashe-Oro)
+working-group: Jason Fabritz (@bugbytesinc), Michiel Mulders (@michielmulders), Ashe Oro (@Ashe-Oro)
 type: Standards Track
 category: Service
 needs-council-approval: Yes


### PR DESCRIPTION
**Description**:
Based on community discussions, this proposal has been updated to the following specification: 

1. Only the admin key should be able to remove itself or other keys.
2. All keys can change themselves to another valid or invalid key (such as all-zeros).

**Related issue(s)**: https://github.com/hashgraph/hedera-improvement-proposal/pull/540#issuecomment-1572204886

**Important Note**: This HIP only focuses on adding key remove and change abilities to the Hedera Token Service. We intend to open a separate HIP for the same capabilities applied to the Hedera Smart Contract Service to keep both HIPs manageable and lightweight to implement. 
