### PR TITLE
Remove all updated dates except latest

### DIFF
--- a/HIP/hip-10.md
+++ b/HIP/hip-10.md
@@ -8,7 +8,7 @@ status: Replaced
 last-call-date-time: 2021-11-23T07:00:00Z
 created: 2021-02-18
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/50
-updated: 2021-05-12, 2021-12-06, 2022-04-19
+updated: 2022-04-19
 superseded-by: 412
 ---
 

--- a/HIP/hip-11.md
+++ b/HIP/hip-11.md
@@ -9,7 +9,7 @@ status: Accepted
 last-call-date-time: 2021-11-23T07:00:00Z
 created: 2021-02-23
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/49
-updated: 2021-05-12, 2021-11-30
+updated: 2021-11-30
 ---
 
 ## Abstract

--- a/HIP/hip-13.md
+++ b/HIP/hip-13.md
@@ -9,7 +9,7 @@ status: Accepted
 last-call-date-time: 2021-11-23T07:00:00Z
 created: 2021-03-13
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/56
-updated: 2021-05-12, 2021-11-30
+updated: 2021-11-30
 ---
 
 ## Abstract

--- a/HIP/hip-14.md
+++ b/HIP/hip-14.md
@@ -9,7 +9,7 @@ superseded-by: 24
 status: Replaced
 created: 2021-03-24
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/59
-updated: 2021-05-12, 2021-11-30
+updated: 2021-11-30
 ---
 
 ## Abstract

--- a/HIP/hip-15.md
+++ b/HIP/hip-15.md
@@ -9,7 +9,7 @@ status: Final
 created: 2021-03-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/47
 requires: 32
-updated: 2021-05-14, 2021-05-23, 2021-12-09
+updated: 2021-12-09
 ---
 
 ## Abstract

--- a/HIP/hip-17.md
+++ b/HIP/hip-17.md
@@ -9,7 +9,7 @@ status: Final
 release: v0.17.2
 created: 2021-04-22
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/74
-updated: 2021-10-27, 2023-02-01, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-171.md
+++ b/HIP/hip-171.md
@@ -9,7 +9,7 @@ status: Final
 last-call-date-time: 2021-11-23T07:00:00Z
 created: 2021-10-18
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/190
-updated: 2021-11-04, 2022-04-26
+updated: 2022-04-26
 ---
 
 ## Abstract

--- a/HIP/hip-18.md
+++ b/HIP/hip-18.md
@@ -7,9 +7,10 @@ category: Service
 needs-council-approval: Yes
 status: Final
 release: v0.16.0
+superseded-by: 573
 created: 2021-04-30
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/92
-updated: 2021-10-27, 2023-02-01
+updated: 2021-10-27
 ---
 ## Abstract
 

--- a/HIP/hip-206.md
+++ b/HIP/hip-206.md
@@ -10,7 +10,7 @@ last-call-date-time: 2021-11-26T07:00:00Z
 release: v0.22.0
 created: 2021-11-04
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/208
-updated: 2022-03-28, 2022-01-10, 2021-11-30, 2021-11-11, 2022-04-26
+updated: 2022-04-26
 ---
 
 ## Abstract

--- a/HIP/hip-21.md
+++ b/HIP/hip-21.md
@@ -10,7 +10,7 @@ last-call-date-time: 2021-11-30T07:00:00Z
 release: v0.22.0
 created: 2021-06-09 
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/82
-updated: 2021-11-15, 2021-11-23, 2022-04-26
+updated: 2022-04-26
 ---
 
 ## Abstract

--- a/HIP/hip-213.md
+++ b/HIP/hip-213.md
@@ -8,7 +8,7 @@ status: Active
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/304
 last-call-date-time: 2021-12-21T07:00:00Z
 created: 2021-11-13
-updated: 2021-11-13, 2021-12-07
+updated: 2021-12-07
 ---
 
 ## Abstract

--- a/HIP/hip-222.md
+++ b/HIP/hip-222.md
@@ -10,7 +10,7 @@ release: v0.21.0
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/221
 last-call-date-time: 2021-11-29T07:00:00Z
 created: 2021-11-15
-updated: 2021-11-30, 2022-04-26
+updated: 2022-04-26
 ---
 
 ## Abstract

--- a/HIP/hip-226.md
+++ b/HIP/hip-226.md
@@ -10,7 +10,7 @@ last-call-date-time: 2021-12-17T07:00:00Z
 release: v0.46
 created: 2021-11-18
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/263
-updated: 2022-04-26, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-227.md
+++ b/HIP/hip-227.md
@@ -10,7 +10,7 @@ status: Final
 last-call-date-time: 2021-12-20T07:00:00Z
 release: v0.47
 created: 2021-11-18
-updated: 2022-04-26, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-23.md
+++ b/HIP/hip-23.md
@@ -9,7 +9,7 @@ status: Final
 release: v0.19.0
 created: 2021-06-22
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/107
-updated: 2021-10-27, 2023-02-01
+updated: 2023-02-01
 ---
 
 **Abstract**

--- a/HIP/hip-24.md
+++ b/HIP/hip-24.md
@@ -9,7 +9,7 @@ status: Final
 release: v0.19.0
 created: 2021-08-09
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/126
-updated: 2021-10-27, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## **Abstract**

--- a/HIP/hip-26.md
+++ b/HIP/hip-26.md
@@ -9,7 +9,7 @@ status: Final
 release: v0.22.0
 created: 2021-09-16
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/140
-updated: 2021-10-27, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-30.md
+++ b/HIP/hip-30.md
@@ -9,7 +9,7 @@ status: Accepted
 last-call-date-time: 2021-11-23T07:00:00Z
 created: 2021-10-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/169
-updated: 2021-10-15, 2021-10-26, 2021-11-11, 2021-11-30
+updated: 2021-11-30
 ---
 
 ## Abstract

--- a/HIP/hip-31.md
+++ b/HIP/hip-31.md
@@ -10,7 +10,7 @@ last-call-date-time: 2021-12-21T07:00:00Z
 release: v0.22.0
 created: 2021-10-14
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/issues/165
-updated: 2021-10-25, 2022-03-16, 2022-04-26
+updated: 2022-04-26
 ---
 
 ## Abstract

--- a/HIP/hip-32.md
+++ b/HIP/hip-32.md
@@ -10,7 +10,7 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discuss
 last-call-date-time: 2021-12-03T07:00:00Z
 release: v0.21.0
 created: 2021-11-01
-updated: 2021-11-30, 2021-12-17, 2022-04-26
+updated: 2022-04-26
 requires: 15
 ---
 

--- a/HIP/hip-33.md
+++ b/HIP/hip-33.md
@@ -9,7 +9,7 @@ status: Final
 last-call-date-time: 2021-11-30T07:00:00Z
 release: v0.22.0
 created: 2021-10-19
-updated: 2021-11-30, 2022-04-26
+updated: 2022-04-26
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/159
 ---
 

--- a/HIP/hip-331.md
+++ b/HIP/hip-331.md
@@ -10,7 +10,7 @@ last-call-date-time: 2022-02-04T07:00:00Z
 release: v0.51
 created: 2021-01-21
 discussions-to: https://github.com/hashgraph/hedera-mirror-node/issues/3081
-updated: 2022-04-26, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-336.md
+++ b/HIP/hip-336.md
@@ -10,7 +10,7 @@ status: Final
 release: v0.25.0
 created: 2022-01-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/337
-updated: 2022-04-11, 2022-05-25
+updated: 2022-05-25
 ---
 
 ## Abstract

--- a/HIP/hip-358.md
+++ b/HIP/hip-358.md
@@ -10,7 +10,7 @@ last-call-date-time: 2022-03-30T07:00:00Z
 release: v0.25.0
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/375
 created: 2022-02-09
-updated: 2022-04-01, 2022-04-11, 2022-05-25, 2022-05-26
+updated: 2022-05-26
 ---
 
 ## Abstract

--- a/HIP/hip-367.md
+++ b/HIP/hip-367.md
@@ -11,7 +11,7 @@ release: v0.25.0
 created: 2022-02-17
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/380
 last-call-date-time: 2022-04-11T07:00:00Z
-updated: 2022-03-31, 2022-04-19, 2022-04-28, 2022-05-25, 2022-09-08
+updated: 2022-09-08
 ---
 
 ## Abstract

--- a/HIP/hip-372.md
+++ b/HIP/hip-372.md
@@ -10,7 +10,7 @@ last-call-date-time: 2022-03-21T07:00:00Z
 created: 2022-03-01
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/382
 replaces: 16
-updated: 2022-04-11, 2023-01-20
+updated: 2023-01-20
 ---
 
 ## Abstract

--- a/HIP/hip-376.md
+++ b/HIP/hip-376.md
@@ -11,7 +11,7 @@ release: v0.26.0
 created: 2022-03-02
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/378
 requires: 206, 218, 336
-updated: 2022-04-19, 2022-05-22, 2022-11-14
+updated: 2022-11-14
 ---
 
 ## Abstract

--- a/HIP/hip-394.md
+++ b/HIP/hip-394.md
@@ -9,7 +9,7 @@ status: Accepted
 last-call-date-time: 2022-04-05T07:00:00Z
 created: 2022-03-08
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/393
-updated: 2022-04-11, 2023-01-20
+updated: 2023-01-20
 ---
 
 ## Abstract

--- a/HIP/hip-410.md
+++ b/HIP/hip-410.md
@@ -11,7 +11,7 @@ last-call-date-time: 2022-04-19T07:00:00Z
 release: v0.26.0
 created: 2022-03-28
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/411
-updated: 2022-04-21, 2022-04-28, 2022-11-14
+updated: 2022-11-14
 ---
 
 ## Abstract

--- a/HIP/hip-415.md
+++ b/HIP/hip-415.md
@@ -12,7 +12,7 @@ created: 2022-03-28
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/434
 last-call-date-time: 2022-05-17T07:00:00Z
 requires: 435
-updated: 2022-05-18, 2023-01-20, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-423.md
+++ b/HIP/hip-423.md
@@ -9,7 +9,7 @@ status: Accepted
 last-call-date-time: 2022-04-25T07:00:00Z
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/425
 created: 2022-04-11
-updated: 2022-04-26, 2022-04-28, 2022-05-23, 2023-01-20
+updated: 2023-01-20
 ---
 
 ## Abstract

--- a/HIP/hip-435.md
+++ b/HIP/hip-435.md
@@ -10,7 +10,7 @@ release: v0.28.0
 last-call-date-time: 2022-05-31T07:00:00Z
 created: 2022-04-13
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/436
-updated: 2023-01-20, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-449.md
+++ b/HIP/hip-449.md
@@ -10,7 +10,7 @@ last-call-date-time: 2022-05-04T07:00:00Z
 release: v0.29.0
 created: 2022-04-19
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/446
-updated: 2022-04-28, 2023-01-20, 2023-02-01
+updated: 2023-02-01
 replaces: 16
 ---
 

--- a/HIP/hip-475.md
+++ b/HIP/hip-475.md
@@ -11,7 +11,7 @@ last-call-date-time: 2022-05-31T07:00:00Z
 release: v0.26.0
 created: 2022-05-12
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/474
-updated: 2023-01-20, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-478.md
+++ b/HIP/hip-478.md
@@ -9,7 +9,7 @@ status: Accepted
 last-call-date-time: 2022-11-15T07:00:00Z
 created: 2022-05-17
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/479
-updated: 2022-09-14, 2022-09-16, 2022-11-01, 2022-11-12, 2022-11-17
+updated: 2022-11-17
 ---
 
 ## Abstract

--- a/HIP/hip-514.md
+++ b/HIP/hip-514.md
@@ -11,7 +11,7 @@ last-call-date-time: 2022-07-26T07:00:00Z
 release: v0.29.0
 created: 2022-06-22
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/516
-updated: 2022-06-28, 2022-07-15, 2022-07-26, 2023-01-20, 2023-02-01
+updated: 2023-02-01
 requires: 206
 ---
 

--- a/HIP/hip-542.md
+++ b/HIP/hip-542.md
@@ -12,7 +12,7 @@ release: v0.31.0
 created: 2022-08-08
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/541
 requires: 32
-updated: 2022-08-24, 2022-09-06, 2022-09-20, 2023-01-20, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-564.md
+++ b/HIP/hip-564.md
@@ -10,7 +10,7 @@ last-call-date-time: 2022-09-21T07:00:00Z
 release: v0.31.0
 created: 2022-09-01
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/563
-updated: 2022-09-07, 2022-10-04, 2022-11-07, 2023-01-20, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-573.md
+++ b/HIP/hip-573.md
@@ -11,9 +11,8 @@ last-call-date-time: 2022-09-27T07:00:00Z
 release: v0.31.0
 created: 2022-09-08
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/571
-requires: 18
 replaces: 18
-updated: 2022-09-13, 2022-09-29, 2023-01-20, 2023-02-01
+updated: 2023-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-631.md
+++ b/HIP/hip-631.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-01-10T07:00:00Z
 created: 2022-11-28
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/637
-updated: 2022-12-17, 2022-12-20, 2023-01-03, 2023-01-10, 2023-02-03
+updated: 2023-02-03
 requires: 583
 ---
 

--- a/HIP/hip-639.md
+++ b/HIP/hip-639.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-01-19T07:00:00Z
 created: 2022-11-29
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/634
-updated: 2023-01-05, 2023-01-19
+updated: 2023-01-19
 ---
 
 ## Abstract

--- a/HIP/hip-646.md
+++ b/HIP/hip-646.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-01-30T07:00:00Z
 created: 2023-01-04
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/627
-updated: 2023-01-04, 2023-01-05, 2023-01-09, 2023-01-10, 2023-01-17, 2023-01-31, 2023-02-07
+updated: 2023-02-07
 ---
 
 ## Abstract

--- a/HIP/hip-657.md
+++ b/HIP/hip-657.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-02-28T07:00:00Z
 created: 2023-01-04
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/607
-updated: 2023-01-21, 2023-01-24, 2023-02-03, 2023-02-15, 2023-02-23, 2023-03-01, 2023-03-07
+updated: 2023-03-07
 ---
 
 

--- a/HIP/hip-766.md
+++ b/HIP/hip-766.md
@@ -8,7 +8,7 @@ needs-council-approval: No
 status: Active
 created: 2023-07-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/766
-updated: 2023-07-11, 2023-07-19, 2023-08-07
+updated: 2023-08-07
 ---
 
 ## Abstract


### PR DESCRIPTION
This pull request focuses on enhancing the data management within the system, specifically regarding the tracking of updated dates among all hips. By eliminating all but the most recently updated dates, the system ensures a more streamlined and efficient representation of this data. 

Note to the reviewer: this pr will cause the validation checker to fail for not having today's date added as the updated date. That's okay. That is expected.