### PR TITLE
Update mirror node handling of staking_reward_rate in HIP-786

### DIFF
--- a/HIP/hip-786.md
+++ b/HIP/hip-786.md
@@ -115,7 +115,7 @@ message NodeStakeUpdateTransactionBody {
 ### Mirror nodes
 
 If a mirror node API exposes network staking properties, it _should_ expand to include this new information
-and _should_ replace the `staking_reward_rate` field with `max_total_reward`. For example,
+and, for an appropriate period of time, _should_ retain the now deprecated `staking_reward_rate` field. For example,
 the Hedera public mirror node currently exposes a `/api/v1/network/stake` endpoint with sample response,
 ```
 {
@@ -134,7 +134,7 @@ the Hedera public mirror node currently exposes a `/api/v1/network/stake` endpoi
 }
 ```
 
-This response should remove the `staking_reward_rate` mapping and expand to include,
+This response should retain all existing mappings, including `staking_reward_rate`, and expand to include,
 ```
 {
   ...

--- a/HIP/hip-786.md
+++ b/HIP/hip-786.md
@@ -115,7 +115,7 @@ message NodeStakeUpdateTransactionBody {
 ### Mirror nodes
 
 If a mirror node API exposes network staking properties, it _should_ expand to include this new information
-and, for an appropriate period of time, _should_ retain the now deprecated `staking_reward_rate` field. For example,
+and _should_ retain the now deprecated `staking_reward_rate` field. For example,
 the Hedera public mirror node currently exposes a `/api/v1/network/stake` endpoint with sample response,
 ```
 {

--- a/HIP/hip-786.md
+++ b/HIP/hip-786.md
@@ -146,7 +146,6 @@ This response should retain all existing mappings, including `staking_reward_rat
 }
 ```
 
-
 ## Backwards Compatibility
 
 This HIP primarily adds new information that mirror node operators and other record stream consumers can simply ignore if 


### PR DESCRIPTION
**Description**:
 - Clarify that mirror node API will retain `staking_reward_rate` field in addition to adding the new ones defined in the HIP.