### PR TITLE
Update hip-796.md to remove "replaces: 751, 752"

### DIFF
--- a/HIP/hip-796.md
+++ b/HIP/hip-796.md
@@ -9,8 +9,7 @@ category: Service
 status: Accepted
 created: 2023-08-30
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/797
-replaces: 751, 752
-updated: 2023-09-13
+updated: 2023-09-27
 ---
 
 ## Abstract


### PR DESCRIPTION
HIP 751 and 752 doesnt exist in the repo so this commit removes that
