### PR TITLE
Move wrapper up so styling doesnt cross over hip title

### DIFF
--- a/_layouts/hip.html
+++ b/_layouts/hip.html
@@ -277,4 +277,8 @@ https://schema.org/TechArticle
     font-size: 12px;
     line-height: 1.2;
   }
+
+  .wrapper {
+    margin-top: -39px;
+  }
 </style>


### PR DESCRIPTION
Before:
![image](https://github.com/hashgraph/hedera-improvement-proposal/assets/101222532/0363508e-4fff-45e9-a24f-7996ae19ca3e)

After:
![image](https://github.com/hashgraph/hedera-improvement-proposal/assets/101222532/056e8fd8-65d6-4896-a6a0-60dc39334cb8)
