### PR TITLE
Update hip-482.md to Active

### DIFF
--- a/HIP/hip-482.md
+++ b/HIP/hip-482.md
@@ -6,11 +6,12 @@ working-group: Daniel Ivanov <daniel-k-ivanov95@gmail.com>, Danno Ferrin <danno.
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2022-06-02T07:00:00Z
 created: 2022-05-19
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/488
 requires: 410, 415
+updated: 2023-11-21
 ---
 
 ## Abstract


### PR DESCRIPTION
This hip needed to be moved to Active state since it doesn't require council approval
