### PR TITLE
HIP-820 signMessages discussion

### DIFF
--- a/HIP/hip-820.md
+++ b/HIP/hip-820.md
@@ -7,7 +7,7 @@ type: Standards Track
 category: Application
 needs-council-approval: No
 status: Review
-created: 2023-10-05
+created: 2023-10-06
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/819
 updated: 2023-11-30
 requires: 30

--- a/HIP/hip-820.md
+++ b/HIP/hip-820.md
@@ -7,9 +7,9 @@ type: Standards Track
 category: Application
 needs-council-approval: No
 status: Review
-created: 2023-10-06
+created: 2023-10-05
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/819
-updated: 2023-11-30
+updated: 2023-12-05
 requires: 30
 replaces: 179
 ---

--- a/HIP/hip-820.md
+++ b/HIP/hip-820.md
@@ -123,8 +123,8 @@ The controller is allowed to retry submitting the query to the Hedera Network fo
 
 `response` – a base64 encoding of the protobuf encoded Hedera API [Response](https://github.com/hashgraph/hedera-protobufs/blob/f36e05bd6bf3f572707ca9bb338f5ad6421a4241/services/response.proto#L68) message.  The response is passed back to the caller without modification and may or may not indicate success.  It is the responsibility of the dApp to decode this protobuf representation into the expected query response results.
 
-### hedera_signMessage
-When a dApp needs to challenge the controller for an off-ledger authentication such as a website login, it can use the `hedera_signMessage` method.  This method accepts a plain text string value as input.  If approved by the user, the controller UTF-8 encodes this message prepended with `"\x19Hedera Signed Message:\n"` plus the length of the message and signs the resulting bytes _in the same manner as HAPI transactions are signed_.   The resulting signature(s) is transmitted back to the user encoded in a `SignatureMap` structure.  The pseudo code for computing the signature is as follows:
+### hedera_signMessages
+When a dApp needs to sign arbitrary data it can pass an array of base64 encoded bytes to the controller (wallet). The resulting array of signed messages are then passed back to the dApp. An example use case is a challenge the for an off-ledger authentication such as a website login, it can use the `hedera_signMessages` method.  WalletConnect also recomends implementing the [AuthAPI](https://docs.walletconnect.com/api/auth/overview) provided by WalletConnect. This method accepts an array of base64 encoded bytes or string with value as input.  If approved by the user, the controller UTF-8 encodes each message prepended with `"\x19Hedera Signed Message:\n"` plus the length of the message and signs the resulting bytes _in the same manner as HAPI transactions are signed_.   The resulting signature(s) are transmitted back to the user as an array of base64 encoded messages. The pseudo code for computing the signature is as follows:
 
 ```
 <Ed25519 or ECDSA Key>.sign("\x19Hedera Signed Message:\n" + len(message) + message)
@@ -133,12 +133,12 @@ When a dApp needs to challenge the controller for an off-ledger authentication s
 It is necessary to add the prefix to the message prior to signing to prevent misuse of the method where a bad actor could request a signature from the controller that could be executable on the hedera network or other chain (in the case where the controller is a multi-chain controller). 
 
 #### Parameters
-`message` – a plain text string to present to the user prior to authorizing a signature.  It is recommended that this be a human readable string and contain identifying information including a timestamp and/or other transient information that can be validated by the user to help prevent replay attacks.
+`messages` – an array of base64 encoded plain text strings or bytes to present to the user prior to authorizing a signature.  It is recommended that this be a human readable string and contain identifying information including a timestamp and/or other transient information that can be validated by the user to help prevent replay attacks.
 
 `signerAccountId` – an Hedera Account identifier in [HIP-30](https://hips.hedera.com/hip/hip-30) (`<nework>:<shard>.<realm>.<num>`) form.  This value identifies the account (and therefore associated key set) that the dApp is requesting to sign the message.  It is permissible to omit this value.  The controller (wallet) may choose to reject the request based on the identifed account or omission of this property, or provide additional signatures beyond the request if the controller deems it necessary or proper.
 
 #### Returns
-`signatureMap` – a base64 encoding of the protobuf endoded Hedera API [`SignatureMap`](https://github.com/hashgraph/hedera-protobufs/blob/f36e05bd6bf3f572707ca9bb338f5ad6421a4241/services/basic_types.proto#L780) message.  The encoded structure must include at least one signature within the property’s [`SignatureMap`](https://github.com/hashgraph/hedera-protobufs/blob/f36e05bd6bf3f572707ca9bb338f5ad6421a4241/services/basic_types.proto#L780) structure.  It is allowed to provide more if the context warrants multiple signatures.
+`signedMessages` – an array of base64 encoded plain text strings or bytes
 
 
 ### hedera_getNodeAddresses


### PR DESCRIPTION
Add an original suggestion to more closely align the `signMessages` function with the signature provider API

**Description**:
This PR is for discussion. In practice, the signer functionality supports multiple messages. This PR is to see if the WalletConnect function should more closely align with that functionality:

https://docs.hedera.com/hedera/sdks-and-apis/sdks/signature-provider/signer