### PR TITLE
Create HIP-859 for adding `gas_consumed` field

### DIFF
--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -6,10 +6,11 @@ working-group: Steven Sheehy <steven.sheehy@swirldslabs.com>, Nana Essilfie-Cond
 type: Standards Track
 category: Mirror
 needs-council-approval: Yes
-status: Review
+status: Last Call
+last-call-date-time: 2024-02-08T07:00:00Z
 created: 2024-01-17
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/860
-updated: 2024-01-22
+updated: 2024-01-25
 ---
 
 ## Abstract

--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -6,7 +6,7 @@ working-group: Steven Sheehy <steven.sheehy@swirldslabs.com>, Nana Essilfie-Cond
 type: Standards Track
 category: Mirror
 needs-council-approval: Yes
-status: Draft
+status: Review
 created: 2024-01-17
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/860
 updated: 2024-01-22

--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -95,7 +95,7 @@ After the change, the API response will look like this:
   "from": "0000000000000000000000000000000000001f41",
   "function_parameters": "0xbb9f02dc6f0e3289f57a1f33b71c73aa8548ab8b",
   "gas_consumed": 55500,
-  "gas_limit": 100000,
+  "gas_limit": 400000,
   "gas_price": "0x4a817c800",
   "gas_used": 320000,
   "hash": "0x3531396130303866616264653464"

--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -7,8 +7,9 @@ type: Standards Track
 category: Mirror
 needs-council-approval: Yes
 status: Draft
-created: 17.01.2024
+created: 2024-01-17
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/860
+updated: 2024-01-22
 ---
 
 ## Abstract

--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -75,6 +75,20 @@ gas_consumed = intrinsic_gas + sum(contract_action_gas_used)
 ```
 gas_consumed = intrinsic_gas + cost(contract_init_bytecode) + sum(contract_action_gas_used)
 ```
+3. The top-level transaction is a ContractCall to a method that have an inner call to another contract
+```
+gas_consumed = intrinsic_gas + sum(contract_action_gas_used_for_top_level_call) + sum(contract_action_gas_used_for_inner_call)
+```
+4. The top-level transaction is a ContractCreate and the created contract deploys another contract in its constructor
+```
+gas_consumed = intrinsic_gas + cost(contract_init_bytecode_for_top_level_create) + sum(contract_action_gas_used_for_top_level_create) + cost(contract_init_bytecode_for_inner_create) + sum(contract_action_gas_used_for_inner_create)
+```
+5. The top-level transaction is a ContractCall, the invoked method deploys a contract and the deployed contract calls another contract in its constructor
+```
+gas_consumed = intrinsic_gas + sum(contract_action_gas_used_for_top_level_call) + cost(contract_init_bytecode_for_inner_create) + sum(contract_action_gas_used_for_inner_create) + sum(contract_action_gas_used_for_inner_call)
+```
+
+Note: For the cases of contract creates the sum of the `contract_action_gas_used` is optional and only applicable if the contract perform some additional actions in its constructor.
 
 The `gas_used` field in `contract_result` table would still have the same semantics and represent the gas that was charged to the user.
 

--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -1,6 +1,6 @@
 ---
-hip: XXX
-title: Add support for gasConsumed field in REST APIs related to transaction information
+hip: 859
+title: Add support for gasConsumed field in REST APIs related to contract results
 author: Ivan Kavaldzhiev <ivan.kavaldzhiev@limechain.tech>, Stoyan Panayotov <stoyan.panayotov@limechain.tech>
 working-group: Steven Sheehy <steven.sheehy@swirldslabs.com>, Nana Essilfie-Conduah <nana@swirldslabs.com>, Danno Ferrin <danno.ferrin@swirldslabs.com>, David Bakin <david.bakin@swirldslabs.com>
 type: Standards Track
@@ -8,6 +8,7 @@ category: Mirror
 needs-council-approval: No
 status: Draft
 created: 17.01.2024
+discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/860
 ---
 
 ## Abstract
@@ -57,7 +58,7 @@ The `gas_used` field in `contract_result` table would still have the same semant
 
 ## Backwards Compatibility
 
-This HIP we will extend the REST APIs responses related to transaction info with an additional field `gasConsumed`. This won't be a breaking change, but the users should have in mind the introduction of the new field.
+This HIP we will extend the REST APIs responses related to transaction info with an additional field `gas_consumed`. This won't be a breaking change, but the users should have in mind the introduction of the new field.
 
 ## Security Implications
 

--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -14,12 +14,12 @@ updated: 2024-01-22
 
 ## Abstract
 
-Currently, consensus nodes export a `gasUsed` field for each EVM impacting transaction and the mirror node persists and exposes this as `gas_used` on the contract result REST APIs. This field value is calculated using the gas refund policy applied in the consensus node.
+Currently, consensus nodes export a `gasUsed` field for each EVM impacting transaction ([ContractCall](https://github.com/hashgraph/hedera-protobufs/blob/v0.46.0/services/contract_call.proto#L43), [ContractCreate](https://github.com/hashgraph/hedera-protobufs/blob/v0.46.0/services/contract_create.proto#L88) and [EthereumTransaction](https://github.com/hashgraph/hedera-protobufs/blob/v0.46.0/services/ethereum_transaction.proto#L31)) and the mirror node persists and exposes this as `gas_used` on the contract result REST APIs. This field value is calculated using the gas refund policy applied in the consensus node.
 This means that the value in this field represents how much gas the user was actually charged, not the amount of gas that the EVM consumed during the execution. This value can greatly differ from the actual amount that was used by the EVM. 
 
 Let's say we use a 20% refund policy for the `gasLimit` that is sent by the user.
 
-That means if the EVM consumes for example 55,500 gas, but the user is passing 400,000 gas limit, they will be charged the `max(55,500, 320,000)`, so it would be 320,000. That is the value calculated after we return the 20% of the gasLimit back to the user, which is 80,000.
+That means if the EVM consumes for example 55,500 gas, but the user is passing 400,000 gas limit, they will be charged the `max(55,500, 0.8 * 400000)`, so it would be 320,000. That is the value calculated after we return the 20% of the gasLimit back to the user, which is 80,000.
 The logic compares the bigger of the two values - the gas consumed by the EVM and the 80% of the `gasLimit` that the user has passed.
 
 In this way we lose track of the actual gas that was consumed by the EVM.
@@ -29,14 +29,14 @@ This HIP will add a new field `gas_consumed` to the mirror node contract result 
 ## Motivation
 
 Adding a `gas_consumed` field to the contract result REST APIs would enrich user experience by providing more information about the transaction. 
-This would allow users to better understand the gas refund policy and the actual gas consumption of their transactions. This would also allow users to understand how heavy their executed transaction was for the EVM.
+This would allow users to better understand the actual gas consumption of their transactions and the gas refund policy. This would also allow users to understand how heavy their executed transaction was for the EVM.
 
 ## Rationale
 
 Consensus nodes export ContractActions sidecar records for each transaction after the introduction of [HIP-513](./hip-513.md). Each sidecar record contains a `gasUsed` field for the given action that the record represents (different type of call or contract creation).
 This value directly represents the gas consumed by the EVM, without taking into account the gas refund policy. This makes it possible to calculate the overall gas consumption for the transaction, during the ContractActions sidecar record importing.  
 
-If we sum up all of the `gasUsed` values of each ContractActions sidecar for a given transaction on top of the initial intrinsic gas, which is the initial gas, charged prior to the transaction execution, then we would get accurate value for the `gasConsumed` field.
+If we sum up all of the `gasUsed` values of each ContractActions sidecar for a given transaction on top of the initial intrinsic gas, which is the initial gas charged prior to the transaction execution, then we would get accurate value for the `gasConsumed` field.
 
 ## User stories
 
@@ -49,8 +49,10 @@ In order to calculate the `gasUsed` field, the mirror node should have `CONTRACT
 which will iterate over all `ContractAction` sidecar records for the transaction we want to import and calculate the `gasConsumed` field for.
 
 The new logic would have a mechanism to first calculate the intrinsic gas cost for the transaction being imported. We can inspect if the transaction has a `ContractBytecode` sidecar
-related to it. If yes, we have a contract creation transaction and we would calculate the intrinsic gas cost based on the length of the init bytecode. If we don't have such a sidecar,
-then the transaction represents a contract call and we would use the default intrinsic gas cost for contract calls, which is 21,000.
+related to it. Then we have the following cases:
+
+- if it has - we have a contract creation transaction and we would calculate the intrinsic gas cost based on the length of the init bytecode
+- if it doesn't have - we have a contract call and we would use the default intrinsic gas cost for contract calls, which is 21,000
 
 The same logic could be applied also to `EthereumTransactions`, since they wrap the same two categories - contract create and contract call. If we have a `ContractBytecode` sidecar for an `EthereumTransaction`, then it wraps a contract create,
 if not, it wraps a contract call.
@@ -63,15 +65,14 @@ For historical contract results we have the following options:
 1. For the contract transactions that were executed after we have started exporting sidecars from consensus nodes, we can make a DB migration in mirror node and populate the `gasConsumed` field for them.
 2. For the contract transactions that were executed prior to the introduction of sidecars or were executed after this period, but have missing sidecar records, we can put a `null` value for the `gasConsumed` field. In this case it would mean the value is not applicable and missing.
 
-```
 Example:
 
 1. The transaction is a ContractCall
-
+```
 gas_consumed = intrinsic_gas + sum(contract_action_gas_used)
-
+```
 2. The transaction is a ContractCreate
-
+```
 gas_consumed = intrinsic_gas + cost(contract_init_bytecode) + sum(contract_action_gas_used)
 ```
 

--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -13,7 +13,7 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discuss
 
 ## Abstract
 
-Currently, consensus nodes export a `gasUsed` field for each EVM impacting transaction, as part of the record streaming. As a result, the `contract_result` table in the mirror node database contains a `gas_used` field for each transaction. This field value is calculated using the gas refund policy applied in the consensus node.
+Currently, consensus nodes export a `gasUsed` field for each EVM impacting transaction and the mirror node persists and exposes this as `gas_used` on the contract result REST APIs. This field value is calculated using the gas refund policy applied in the consensus node.
 This means that the value in this field represents how much gas the user was actually charged, not the amount of gas that the EVM consumed during the execution. This value can greatly differ from the actual amount that was used by the EVM. 
 
 Let's say we use a 20% refund policy for the `gasLimit` that is sent by the user.
@@ -23,11 +23,11 @@ The logic compares the bigger of the two values - the gas consumed by the EVM an
 
 In this way we lose track of the actual gas that was consumed by the EVM.
 
-This HIP will add a new field `gas_consumed` to the `contract_result` table in the mirror node, which will contain the actually consumed gas by the EVM.
+This HIP will add a new field `gas_consumed` to the mirror node contract result REST APIs, which will contain the actually consumed gas by the EVM.
 
 ## Motivation
 
-Adding a `gas_consumed` field in the `contract_result` table would enrich user experience by providing more information about the transaction. 
+Adding a `gas_consumed` field to the contract result REST APIs would enrich user experience by providing more information about the transaction. 
 This would allow users to better understand the gas refund policy and the actual gas consumption of their transactions. This would also allow users to understand how heavy their executed transaction was for the EVM.
 
 ## Rationale

--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -18,23 +18,12 @@ This means that the value in this field represents how much gas the user was act
 
 Let's say we use a 20% refund policy for the `gasLimit` that is sent by the user.
 
-That means if the EVM consumes for example 55_500 gas, but the user is passing 400_000 gas limit, they will be charged the `max(55_500, 320_000)`, so it would be 320_000. That is the value calculated after we return the 20% of the gasLimit back to the user, which is 80_000.
+That means if the EVM consumes for example 55,500 gas, but the user is passing 400,000 gas limit, they will be charged the `max(55,500, 320,000)`, so it would be 320,000. That is the value calculated after we return the 20% of the gasLimit back to the user, which is 80,000.
 The logic compares the bigger of the two values - the gas consumed by the EVM and the 80% of the `gasLimit` that the user has passed.
 
 In this way we lose track of the actual gas that was consumed by the EVM.
 
 This HIP will add a new field `gas_consumed` to the `contract_result` table in the mirror node, which will contain the actually consumed gas by the EVM.
-
-```
-create table if not exists contract_result
-(
-...
-gas_limit            bigint       not null,
-gas_consumed         bigint       null,
-gas_used             bigint       null,
-...
-)
-```
 
 ## Motivation
 
@@ -58,12 +47,20 @@ If we sum up all of the `gasUsed` values of each ContractActions sidecar for a g
 In order to calculate the `gasUsed` field, the mirror node should have `CONTRACT_ACTION` and `CONTRACT_BYTECODE` sidecars enabled. Then, we would use an enhancement logic in the `mirror-node-importer`,
 which will iterate over all `ContractAction` sidecar records for the transaction we want to import and calculate the `gasConsumed` field for.
 
-The new logic would have a mechanism to first calculate the intrinsic gas cost for the transaction being imported. We can inspect if the transaction has a `ContractByteCode` sidecar
+The new logic would have a mechanism to first calculate the intrinsic gas cost for the transaction being imported. We can inspect if the transaction has a `ContractBytecode` sidecar
 related to it. If yes, we have a contract creation transaction and we would calculate the intrinsic gas cost based on the length of the init bytecode. If we don't have such a sidecar,
-then the transaction represents a contract call and we would use the default intrinsic gas cost for contract calls, which is 21 000.
+then the transaction represents a contract call and we would use the default intrinsic gas cost for contract calls, which is 21,000.
+
+The same logic could be applied also to `EthereumTransactions`, since they wrap the same two categories - contract create and contract call. If we have a `ContractBytecode` sidecar for an `EthereumTransaction`, then it wraps a contract create,
+if not, it wraps a contract call.
 
 On top of the intrinsic gas cost, we would iterate over all `ContractAction`
 sidecars and sum up the `gasUsed` field for each of them. The result would be the `gasConsumed` field for the transaction.
+
+For historical contract results we have the following options:
+
+1. For the contract transactions that were executed after we have started exporting sidecars from consensus nodes, we can make a DB migration in mirror node and populate the `gasConsumed` field for them.
+2. For the contract transactions that were executed prior to the introduction of sidecars or were executed after this period, but have missing sidecar records, we can put a `null` value for the `gasConsumed` field. In this case it would mean the value is not applicable and missing.
 
 ```
 Example:
@@ -88,28 +85,10 @@ The following REST APIs will be extended with the new field:
 4. GET /api/v1/contracts/{contractIdOrAddress}/results/{timestamp}
 ```
 
-The current response from these APIs looks like this:
+After the change, the API response will look like this:
 
 ```json
 {
-  ...
-  "error_message": "Out of gas",
-  "failed_initcode": "0x856739",
-  "from": "0000000000000000000000000000000000001f41",
-  "function_parameters": "0xbb9f02dc6f0e3289f57a1f33b71c73aa8548ab8b",
-  "gas_limit": 100000,
-  "gas_price": "0x4a817c800",
-  "gas_used": 320000,
-  "hash": "0x3531396130303866616264653464",
-  ...
-}
-```
-
-After the change, it will look like this:
-
-```json
-{
-  ...
   "error_message": "Out of gas",
   "failed_initcode": "0x856739",
   "from": "0000000000000000000000000000000000001f41",
@@ -118,10 +97,11 @@ After the change, it will look like this:
   "gas_limit": 100000,
   "gas_price": "0x4a817c800",
   "gas_used": 320000,
-  "hash": "0x3531396130303866616264653464",
-  ...
+  "hash": "0x3531396130303866616264653464"
 }
 ```
+
+Some fields in this example are omitted for brevity.
 
 
 ## Backwards Compatibility
@@ -144,13 +124,14 @@ Please follow [this issue](https://github.com/hashgraph/hedera-mirror-node/issue
 
 While discussing the implementation of this HIP, we considered the following alternatives:
 
-1. Adding a new `gasConsumed` field to the Record Stream V6 format, which would be a breaking change in the protobuf format and would require a new version of the Record Stream to be introduced.
+1. Adding a new `gasConsumed` field to the Record Stream V6 format. This change would have had an impact on the whole ecosystem.
 2. Changing the semantics of the current `gasUsed` field to start representing the gas consumed by the EVM, instead of the gas charged to the user. This approach would have been confusing for the community.
 3. Calculating the `gasConsumed` field on the fly, when the user requests the transaction info from the mirror-node REST APIs. This would have been a performance issue, as we would have to iterate over all `ContractAction` sidecars for the transaction and calculate the `gasConsumed` field every time the user requests the transaction info.
 
 ## References
 
 - [HIP-226](https://hips.hedera.com/hip/hip-226) - Mirror Node Contract Execution Results REST API
+- [HIP-410](https://hips.hedera.com/hip/hip-410) - Wrapping Ethereum Transaction Bytes in a Hedera Transaction
 - [HIP-513](https://hips.hedera.com/hip/hip-513) - Smart Contract Traceability Extension
 
 ## Copyright/license

--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -5,7 +5,7 @@ author: Ivan Kavaldzhiev <ivan.kavaldzhiev@limechain.tech>, Stoyan Panayotov <st
 working-group: Steven Sheehy <steven.sheehy@swirldslabs.com>, Nana Essilfie-Conduah <nana@swirldslabs.com>, Danno Ferrin <danno.ferrin@swirldslabs.com>, David Bakin <david.bakin@swirldslabs.com>
 type: Standards Track
 category: Mirror
-needs-council-approval: No
+needs-council-approval: Yes
 status: Draft
 created: 17.01.2024
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/860
@@ -13,17 +13,28 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discuss
 
 ## Abstract
 
-Currently, consensus nodes export a `gasUsed` field for each transaction, part of the record streaming. As a result, the `contract_result` table in the mirror node database contains a `gas_used` field for each transaction. This field value is calculated using the gas refund policy applied in the consensus node.
+Currently, consensus nodes export a `gasUsed` field for each EVM impacting transaction, as part of the record streaming. As a result, the `contract_result` table in the mirror node database contains a `gas_used` field for each transaction. This field value is calculated using the gas refund policy applied in the consensus node.
 This means that the value in this field represents how much gas the user was actually charged, not the amount of gas that the EVM consumed during the execution. This value can greatly differ from the actual amount that was used by the EVM. 
 
 Let's say we use a 20% refund policy for the `gasLimit` that is sent by the user.
 
-That means if the EVM consumes for example 32 500 gas, but the user is passing 400 000 gas limit, they will be charged the `max(32 500, 320 000)`, so it would be 320 000. That is the value calculated after we return the 20% of the gasLimit back to the user, which is 80 000.
+That means if the EVM consumes for example 55_500 gas, but the user is passing 400_000 gas limit, they will be charged the `max(55_500, 320_000)`, so it would be 320_000. That is the value calculated after we return the 20% of the gasLimit back to the user, which is 80_000.
 The logic compares the bigger of the two values - the gas consumed by the EVM and the 80% of the `gasLimit` that the user has passed.
 
 In this way we lose track of the actual gas that was consumed by the EVM.
 
 This HIP will add a new field `gas_consumed` to the `contract_result` table in the mirror node, which will contain the actually consumed gas by the EVM.
+
+```
+create table if not exists contract_result
+(
+...
+gas_limit            bigint       not null,
+gas_consumed         bigint       null,
+gas_used             bigint       null,
+...
+)
+```
 
 ## Motivation
 
@@ -32,7 +43,7 @@ This would allow users to better understand the gas refund policy and the actual
 
 ## Rationale
 
-Consensus nodes export ContractActions sidecar records for each transaction after the introducing of [HIP-513](./hip-513.md). Each sidecar record contains a `gasUsed` field for the given action that the record represents (different type of call or contract creation).
+Consensus nodes export ContractActions sidecar records for each transaction after the introduction of [HIP-513](./hip-513.md). Each sidecar record contains a `gasUsed` field for the given action that the record represents (different type of call or contract creation).
 This value directly represents the gas consumed by the EVM, without taking into account the gas refund policy. This makes it possible to calculate the overall gas consumption for the transaction, during the ContractActions sidecar record importing.  
 
 If we sum up all of the `gasUsed` values of each ContractActions sidecar for a given transaction on top of the initial intrinsic gas, which is the initial gas, charged prior to the transaction execution, then we would get accurate value for the `gasConsumed` field.
@@ -54,7 +65,64 @@ then the transaction represents a contract call and we would use the default int
 On top of the intrinsic gas cost, we would iterate over all `ContractAction`
 sidecars and sum up the `gasUsed` field for each of them. The result would be the `gasConsumed` field for the transaction.
 
+```
+Example:
+
+1. The transaction is a ContractCall
+
+gas_consumed = intrinsic_gas + sum(contract_action_gas_used)
+
+2. The transaction is a ContractCreate
+
+gas_consumed = intrinsic_gas + cost(contract_init_bytecode) + sum(contract_action_gas_used)
+```
+
 The `gas_used` field in `contract_result` table would still have the same semantics and represent the gas that was charged to the user.
+
+The following REST APIs will be extended with the new field:
+
+```
+1. GET /api/v1/contracts/results
+2. GET /api/v1/contracts/results/{transactionIdOrHash}
+3. GET /api/v1/contracts/{contractIdOrAddress}/results 
+4. GET /api/v1/contracts/{contractIdOrAddress}/results/{timestamp}
+```
+
+The current response from these APIs looks like this:
+
+```json
+{
+  ...
+  "error_message": "Out of gas",
+  "failed_initcode": "0x856739",
+  "from": "0000000000000000000000000000000000001f41",
+  "function_parameters": "0xbb9f02dc6f0e3289f57a1f33b71c73aa8548ab8b",
+  "gas_limit": 100000,
+  "gas_price": "0x4a817c800",
+  "gas_used": 320000,
+  "hash": "0x3531396130303866616264653464",
+  ...
+}
+```
+
+After the change, it will look like this:
+
+```json
+{
+  ...
+  "error_message": "Out of gas",
+  "failed_initcode": "0x856739",
+  "from": "0000000000000000000000000000000000001f41",
+  "function_parameters": "0xbb9f02dc6f0e3289f57a1f33b71c73aa8548ab8b",
+  "gas_consumed": 55500,
+  "gas_limit": 100000,
+  "gas_price": "0x4a817c800",
+  "gas_used": 320000,
+  "hash": "0x3531396130303866616264653464",
+  ...
+}
+```
+
 
 ## Backwards Compatibility
 
@@ -74,12 +142,15 @@ Please follow [this issue](https://github.com/hashgraph/hedera-mirror-node/issue
 
 ## Rejected Ideas
 
-While discussing the implementation of this HIP, we considered the following alternative:
+While discussing the implementation of this HIP, we considered the following alternatives:
 
-Adding a new `gasConsumed` field to the Record Stream V6 format, which would be a breaking change in the protobuf format and would require a new version of the Record Stream to be introduced.
+1. Adding a new `gasConsumed` field to the Record Stream V6 format, which would be a breaking change in the protobuf format and would require a new version of the Record Stream to be introduced.
+2. Changing the semantics of the current `gasUsed` field to start representing the gas consumed by the EVM, instead of the gas charged to the user. This approach would have been confusing for the community.
+3. Calculating the `gasConsumed` field on the fly, when the user requests the transaction info from the mirror-node REST APIs. This would have been a performance issue, as we would have to iterate over all `ContractAction` sidecars for the transaction and calculate the `gasConsumed` field every time the user requests the transaction info.
 
 ## References
 
+- [HIP-226](https://hips.hedera.com/hip/hip-226) - Mirror Node Contract Execution Results REST API
 - [HIP-513](https://hips.hedera.com/hip/hip-513) - Smart Contract Traceability Extension
 
 ## Copyright/license

--- a/HIP/hip-xxx.md
+++ b/HIP/hip-xxx.md
@@ -1,0 +1,86 @@
+---
+hip: XXX
+title: Add support for gasConsumed field in REST APIs related to transaction information
+author: Ivan Kavaldzhiev <ivan.kavaldzhiev@limechain.tech>, Stoyan Panayotov <stoyan.panayotov@limechain.tech>
+working-group: Steven Sheehy <steven.sheehy@swirldslabs.com>, Nana Essilfie-Conduah <nana@swirldslabs.com>, Danno Ferrin <danno.ferrin@swirldslabs.com>, David Bakin <david.bakin@swirldslabs.com>
+type: Standards Track
+category: Mirror
+needs-council-approval: No
+status: Draft
+created: 17.01.2024
+---
+
+## Abstract
+
+Currently, consensus nodes export a `gasUsed` field for each transaction, part of the record streaming. As a result, the `contract_result` table in the mirror node database contains a `gas_used` field for each transaction. This field value is calculated using the gas refund policy applied in the consensus node.
+This means that the value in this field represents how much gas the user was actually charged, not the amount of gas that the EVM consumed during the execution. This value can greatly differ from the actual amount that was used by the EVM. 
+
+Let's say we use a 20% refund policy for the `gasLimit` that is sent by the user.
+
+That means if the EVM consumes for example 32 500 gas, but the user is passing 400 000 gas limit, they will be charged the `max(32 500, 320 000)`, so it would be 320 000. That is the value calculated after we return the 20% of the gasLimit back to the user, which is 80 000.
+The logic compares the bigger of the two values - the gas consumed by the EVM and the 80% of the `gasLimit` that the user has passed.
+
+In this way we lose track of the actual gas that was consumed by the EVM.
+
+This HIP will add a new field `gas_consumed` to the `contract_result` table in the mirror node, which will contain the actually consumed gas by the EVM.
+
+## Motivation
+
+Adding a `gas_consumed` field in the `contract_result` table would enrich user experience by providing more information about the transaction. 
+This would allow users to better understand the gas refund policy and the actual gas consumption of their transactions. This would also allow users to understand how heavy their executed transaction was for the EVM.
+
+## Rationale
+
+Consensus nodes export ContractActions sidecar records for each transaction after the introducing of [HIP-513](./hip-513.md). Each sidecar record contains a `gasUsed` field for the given action that the record represents (different type of call or contract creation).
+This value directly represents the gas consumed by the EVM, without taking into account the gas refund policy. This makes it possible to calculate the overall gas consumption for the transaction, during the ContractActions sidecar record importing.  
+
+If we sum up all of the `gasUsed` values of each ContractActions sidecar for a given transaction on top of the initial intrinsic gas, which is the initial gas, charged prior to the transaction execution, then we would get accurate value for the `gasConsumed` field.
+
+## User stories
+
+1. As a user, I want to see how much gas was consumed by the EVM during the execution of my transaction, when I retrieve a transaction info from the mirror-node REST APIs, so that I know if I can optimise my transaction cost
+2. As a user, I want to see and compare how much gas I was charged for and how much gas was consumed by the EVM, when I inspect my transaction in hashscan
+
+## Specification
+
+In order to calculate the `gasUsed` field, the mirror node should have `CONTRACT_ACTION` and `CONTRACT_BYTECODE` sidecars enabled. Then, we would use an enhancement logic in the `mirror-node-importer`,
+which will iterate over all `ContractAction` sidecar records for the transaction we want to import and calculate the `gasConsumed` field for.
+
+The new logic would have a mechanism to first calculate the intrinsic gas cost for the transaction being imported. We can inspect if the transaction has a `ContractByteCode` sidecar
+related to it. If yes, we have a contract creation transaction and we would calculate the intrinsic gas cost based on the length of the init bytecode. If we don't have such a sidecar,
+then the transaction represents a contract call and we would use the default intrinsic gas cost for contract calls, which is 21 000.
+
+On top of the intrinsic gas cost, we would iterate over all `ContractAction`
+sidecars and sum up the `gasUsed` field for each of them. The result would be the `gasConsumed` field for the transaction.
+
+The `gas_used` field in `contract_result` table would still have the same semantics and represent the gas that was charged to the user.
+
+## Backwards Compatibility
+
+This HIP we will extend the REST APIs responses related to transaction info with an additional field `gasConsumed`. This won't be a breaking change, but the users should have in mind the introduction of the new field.
+
+## Security Implications
+
+None
+
+## How to Teach This
+
+Respective documentation will be added.
+
+## Reference Implementation
+
+Please follow [this issue](https://github.com/hashgraph/hedera-mirror-node/issues/7543)
+
+## Rejected Ideas
+
+While discussing the implementation of this HIP, we considered the following alternative:
+
+Adding a new `gasConsumed` field to the Record Stream V6 format, which would be a breaking change in the protobuf format and would require a new version of the Record Stream to be introduced.
+
+## References
+
+- [HIP-513](https://hips.hedera.com/hip/hip-513) - Smart Contract Traceability Extension
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](../LICENSE) or (https://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR adds a HIP for introduction of a new field in `contract_result` table in mirror node, called `gas_consumed`. It will represent the actually consumed gas by the EVM and would differ from the existing `gas_used` field, which represents the gas that was charged to the user, including the gas refund policy on consensus nodes.

This new field would provide a deeper understanding of how compute heavy the transaction was for the EVM and users could compare how much they were charged for a transaction and how much gas was actually used by the EVM. We can also use this field to enrich the hashscan information displayed for a given transaction.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
