### PR TITLE
Update token metadata HIPs with proposed mirror node REST API responses.

### DIFF
--- a/HIP/hip-646.md
+++ b/HIP/hip-646.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-01-30T07:00:00Z
 created: 2023-01-04
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/627
-updated: 2024-02-01
+updated: 2024-02-02
 ---
 
 ## Abstract

--- a/HIP/hip-646.md
+++ b/HIP/hip-646.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-01-30T07:00:00Z
 created: 2023-01-04
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/627
-updated: 2024-01-29
+updated: 2024-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-646.md
+++ b/HIP/hip-646.md
@@ -94,16 +94,18 @@ message TokenInfo {
 Pricing considerations:
 The price for this metadata will be identical to the cost for storage of the memo.
 
-### Hedera REST API Changes
+### Mirror Node Changes
 
-Only for individual NFTs does the Mirror Node REST API currently return a base64 encoded representation of the `metadata` field. This will be extended to an entire token type, both fungible (this HIP) and non-fungible token collections ([HIP-765](https://hips.hedera.com/hip/hip-765)).
+Currently, only for individual NFTs does the Mirror Node REST API return the `metadata` field. This will be extended to an entire token type for both fungible (this HIP) and non-fungible token collections ([HIP-765](https://hips.hedera.com/hip/hip-765)).
 
 #### /api/v1/tokens
+
+For the list tokens endpoint, the token level `metadata` field will be returned as a base64 encoded value.
 
 ```json
 {
     "links": {
-        "next": "/api/v1/tokens?token.id=gt:0.0.1107"
+        "next": null
     },
     "tokens": [
         {
@@ -125,15 +127,14 @@ Only for individual NFTs does the Mirror Node REST API currently return a base64
             "symbol": "non_fungible",
             "token_id": "0.0.1036",
             "type": "NON_FUNGIBLE_UNIQUE"
-        },
-        ...
+        }
     ]
 }
 ```
 
 #### /api/v1/tokens/{tokenId}
 
-For a given token ID, in addition to the `metadata` field, the new `metadata_key` ([HIP-657](https://hips.hedera.com/hip/hip-657)) will also be returned in the standard key format.
+For a given token ID, in addition to the base64 encoded `metadata` field, the new `metadata_key` ([HIP-657](https://hips.hedera.com/hip/hip-657)) will also be returned in the standard key format.
 
 ```json
 {

--- a/HIP/hip-646.md
+++ b/HIP/hip-646.md
@@ -94,6 +94,102 @@ message TokenInfo {
 Pricing considerations:
 The price for this metadata will be identical to the cost for storage of the memo.
 
+### Hedera REST API Changes
+
+Only for individual NFTs does the Mirror Node REST API currently return a base64 encoded representation of the `metadata` field. This will be extended to an entire token type, both fungible (this HIP) and non-fungible token collections ([HIP-765](https://hips.hedera.com/hip/hip-765)).
+
+#### /api/v1/tokens
+
+```json
+{
+    "links": {
+        "next": "/api/v1/tokens?token.id=gt:0.0.1107"
+    },
+    "tokens": [
+        {
+            "admin_key": {
+                "_type": "ED25519",
+                "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+            },
+            "metadata": "Ag==",
+            "symbol": "fungible",
+            "token_id": "0.0.1032",
+            "type": "FUNGIBLE_COMMON"
+        },
+        {
+            "admin_key": {
+                "_type": "ED25519",
+                "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+            },
+            "metadata": "VEVTVF9tZXRhZGF0YQ==",
+            "symbol": "non_fungible",
+            "token_id": "0.0.1036",
+            "type": "NON_FUNGIBLE_UNIQUE"
+        },
+        ...
+    ]
+}
+```
+
+#### /api/v1/tokens/{tokenId}
+
+For a given token ID, in addition to the `metadata` field, the new `metadata_key` ([HIP-657](https://hips.hedera.com/hip/hip-657)) will also be returned in the standard key format.
+
+```json
+{
+    "admin_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "auto_renew_account": "0.0.1020",
+    "auto_renew_period": 6999999,
+    "created_timestamp": "1706556543.894559367",
+    "custom_fees": {
+        "created_timestamp": "1706556543.894559367",
+        "fixed_fees": [],
+        "royalty_fees": []
+    },
+    "decimals": "0",
+    "deleted": true,
+    "expiry_timestamp": 1713556542894559367,
+    "fee_schedule_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "freeze_default": false,
+    "freeze_key": null,
+    "initial_supply": "0",
+    "kyc_key": null,
+    "max_supply": "0",
+    "memo": "Mirror Node acceptance test: 2024-01-29T19:29:03.525656Z Create token",
+    "metadata": "VEVTVF9tZXRhZGF0YQ==",
+    "metadata_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "modified_timestamp": "1706556543.894559367",
+    "name": "non_fungible_name",
+    "pause_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "pause_status": "UNPAUSED",
+    "supply_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "supply_type": "INFINITE",
+    "symbol": "non_fungible",
+    "token_id": "0.0.1036",
+    "total_supply": "0",
+    "treasury_account_id": "0.0.1020",
+    "type": "NON_FUNGIBLE_UNIQUE",
+    "wipe_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    }
+}
+```
 
 ## Backwards Compatibility
 

--- a/HIP/hip-657.md
+++ b/HIP/hip-657.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-02-28T07:00:00Z
 created: 2023-01-04
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/607
-updated: 2024-01-29
+updated: 2024-02-01
 ---
 
 

--- a/HIP/hip-657.md
+++ b/HIP/hip-657.md
@@ -135,7 +135,7 @@ message TokenInfo {
 }
 ```
 
-### Hedera REST API Changes
+### Mirror Node Changes
 
 Given the introduced `metadata_key` is applicable to the token type (fungible and non-fungible) and is used to manage both the metadata for the overall collection as well as that for individual NFTs, the REST API token level response is where the metadata key is returned and not for individual NFTs via `/api/v1/tokens/{tokenId}/nfts/{serial}`.
 

--- a/HIP/hip-657.md
+++ b/HIP/hip-657.md
@@ -135,6 +135,70 @@ message TokenInfo {
 }
 ```
 
+### Hedera REST API Changes
+
+Given the introduced `metadata_key` is applicable to the token type (fungible and non-fungible) and is used to manage both the metadata for the overall collection as well as that for individual NFTs, the REST API token level response is where the metadata key is returned and not for individual NFTs via `/api/v1/tokens/{tokenId}/nfts/{serial}`.
+
+#### /api/v1/tokens/{tokenId}
+
+For any token, the `metadata_key` is returned in the standard key format, along with the base64 encoded token/collection level `metadata`. If no metadata key is set for the token, then `"metadata_key": null` is returned.
+
+```json
+{
+    "admin_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "auto_renew_account": "0.0.1020",
+    "auto_renew_period": 6999999,
+    "created_timestamp": "1706556543.894559367",
+    "custom_fees": {
+        "created_timestamp": "1706556543.894559367",
+        "fixed_fees": [],
+        "royalty_fees": []
+    },
+    "decimals": "0",
+    "deleted": true,
+    "expiry_timestamp": 1713556542894559367,
+    "fee_schedule_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "freeze_default": false,
+    "freeze_key": null,
+    "initial_supply": "0",
+    "kyc_key": null,
+    "max_supply": "0",
+    "memo": "Mirror Node acceptance test: 2024-01-29T19:29:03.525656Z Create token",
+    "metadata": "VEVTVF9tZXRhZGF0YQ==",
+    "metadata_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "modified_timestamp": "1706556543.894559367",
+    "name": "non_fungible_name",
+    "pause_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "pause_status": "UNPAUSED",
+    "supply_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "supply_type": "INFINITE",
+    "symbol": "non_fungible",
+    "token_id": "0.0.1036",
+    "total_supply": "0",
+    "treasury_account_id": "0.0.1020",
+    "type": "NON_FUNGIBLE_UNIQUE",
+    "wipe_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    }
+}
+```
+
 ## Backwards Compatibility
 
 

--- a/HIP/hip-657.md
+++ b/HIP/hip-657.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-02-28T07:00:00Z
 created: 2023-01-04
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/607
-updated: 2024-02-01
+updated: 2024-02-02
 ---
 
 

--- a/HIP/hip-765.md
+++ b/HIP/hip-765.md
@@ -95,6 +95,102 @@ Pricing considerations:
 
 - The price for this metadata will be identical to the cost for storage of the memo.
 
+### Hedera REST API Changes
+
+Only for individual NFTs does the Mirror Node REST API currently return a base64 encoded representation of the `metadata` field. This will be extended to an entire token type, both fungible ([HIP-646](https://hips.hedera.com/hip/hip-646)) and non-fungible token collections (this HIP).
+
+#### /api/v1/tokens
+
+```json
+{
+    "links": {
+        "next": "/api/v1/tokens?token.id=gt:0.0.1107"
+    },
+    "tokens": [
+        {
+            "admin_key": {
+                "_type": "ED25519",
+                "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+            },
+            "metadata": "Ag==",
+            "symbol": "fungible",
+            "token_id": "0.0.1032",
+            "type": "FUNGIBLE_COMMON"
+        },
+        {
+            "admin_key": {
+                "_type": "ED25519",
+                "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+            },
+            "metadata": "VEVTVF9tZXRhZGF0YQ==",
+            "symbol": "non_fungible",
+            "token_id": "0.0.1036",
+            "type": "NON_FUNGIBLE_UNIQUE"
+        },
+        ...
+    ]
+}
+```
+
+#### /api/v1/tokens/{tokenId}
+
+For a given token ID, in addition to the `metadata` field, the new `metadata_key` ([HIP-657](https://hips.hedera.com/hip/hip-657)) will also be returned in the standard key format.
+
+```json
+{
+    "admin_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "auto_renew_account": "0.0.1020",
+    "auto_renew_period": 6999999,
+    "created_timestamp": "1706556543.894559367",
+    "custom_fees": {
+        "created_timestamp": "1706556543.894559367",
+        "fixed_fees": [],
+        "royalty_fees": []
+    },
+    "decimals": "0",
+    "deleted": true,
+    "expiry_timestamp": 1713556542894559367,
+    "fee_schedule_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "freeze_default": false,
+    "freeze_key": null,
+    "initial_supply": "0",
+    "kyc_key": null,
+    "max_supply": "0",
+    "memo": "Mirror Node acceptance test: 2024-01-29T19:29:03.525656Z Create token",
+    "metadata": "VEVTVF9tZXRhZGF0YQ==",
+    "metadata_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "modified_timestamp": "1706556543.894559367",
+    "name": "non_fungible_name",
+    "pause_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "pause_status": "UNPAUSED",
+    "supply_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    },
+    "supply_type": "INFINITE",
+    "symbol": "non_fungible",
+    "token_id": "0.0.1036",
+    "total_supply": "0",
+    "treasury_account_id": "0.0.1020",
+    "type": "NON_FUNGIBLE_UNIQUE",
+    "wipe_key": {
+        "_type": "ED25519",
+        "key": "0aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"
+    }
+}
+```
 
 ## Backwards Compatibility
 

--- a/HIP/hip-765.md
+++ b/HIP/hip-765.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-07-28T07:00:00Z
 created: 2023-07-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/765
-updated: 2024-01-29
+updated: 2024-02-01
 ---
 
 ## Abstract

--- a/HIP/hip-765.md
+++ b/HIP/hip-765.md
@@ -95,16 +95,18 @@ Pricing considerations:
 
 - The price for this metadata will be identical to the cost for storage of the memo.
 
-### Hedera REST API Changes
+### Mirror Node Changes
 
-Only for individual NFTs does the Mirror Node REST API currently return a base64 encoded representation of the `metadata` field. This will be extended to an entire token type, both fungible ([HIP-646](https://hips.hedera.com/hip/hip-646)) and non-fungible token collections (this HIP).
+Currently, only for individual NFTs does the Mirror Node REST API return the `metadata` field. This will be extended to an entire token type for both fungible ([HIP-646](https://hips.hedera.com/hip/hip-646)) and non-fungible token collections (this HIP).
 
 #### /api/v1/tokens
+
+For the list tokens endpoint, the token level `metadata` field will be returned as a base64 encoded value.
 
 ```json
 {
     "links": {
-        "next": "/api/v1/tokens?token.id=gt:0.0.1107"
+        "next": null
     },
     "tokens": [
         {
@@ -126,8 +128,7 @@ Only for individual NFTs does the Mirror Node REST API currently return a base64
             "symbol": "non_fungible",
             "token_id": "0.0.1036",
             "type": "NON_FUNGIBLE_UNIQUE"
-        },
-        ...
+        }
     ]
 }
 ```

--- a/HIP/hip-765.md
+++ b/HIP/hip-765.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-07-28T07:00:00Z
 created: 2023-07-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/765
-updated: 2024-02-01
+updated: 2024-02-02
 ---
 
 ## Abstract


### PR DESCRIPTION
**Description**:
This PR adds Hedera REST (mirror node) API response updates to reflect the token `metadata` and `metadata_key` fields defined in HIP-646, HIP-657 and HIP-765.

