### PR TITLE
Parse working group data similar to author data

### DIFF
--- a/_includes/workinggrouplist.html
+++ b/_includes/workinggrouplist.html
@@ -1,0 +1,13 @@
+{%- assign working_groups = include.working-group | split: "," -%}
+{%- for group in working_groups -%}
+    {%- if group contains "<" -%}
+        {%- assign groupparts = group | split: "<" -%}
+        <a href="mailto:{{ groupparts[1] | remove: ">" }}">{{ groupparts[0] | strip }}</a>
+    {%- elsif group contains "(@" -%}
+        {%- assign groupparts = group | split: "(@" -%}
+        <a href="https://github.com/{{ groupparts[1] | remove: ")" }}">{{ groupparts[0] | strip }}</a>
+    {%- else -%}
+        {{ group }}
+    {%- endif -%}
+    {% if forloop.last == false %}, {% endif %}
+{%- endfor -%}

--- a/_layouts/hip.html
+++ b/_layouts/hip.html
@@ -39,7 +39,7 @@ layout: default
     {% if page["working-group"] != undefined %}
     <tr>
       <th>Working Group</th>
-      <td>{{ page.working-group }}</td>
+      <td>{% include workinggrouplist.html working-group=page.working-group %}</td>
     </tr>
     {% endif %}
     {% if page["requested-by"] != undefined %}


### PR DESCRIPTION
**Description**:
This hip parses the data in the working group header in the same way as the author list so users can click on the data and go to the user github profile or their email 
<img width="1061" alt="image" src="https://github.com/hashgraph/hedera-improvement-proposal/assets/101222532/99e34833-7ca5-4787-8eda-e3b57d896d30">
