### PR TITLE
Distinguish calls to EOAs and contracts 

### DIFF
--- a/HIP/hip-906.md
+++ b/HIP/hip-906.md
@@ -11,7 +11,7 @@ status: Last Call
 last-call-date-time: 2024-05-01T07:00:00Z
 created: 2024-02-23
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/906
-updated: 2024-04-22
+updated: 2024-04-23
 requires: 632
 ---
 
@@ -28,7 +28,7 @@ The lack of a mechanism to grant allowance and approval for hbars without using 
 ## Rationale
 
 [HIP-632](https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-632.md) proposed to introduce a new system contract for accessing Hedera account functionality (Hedera Account Service - HAS).  
-This HIP proposes adding missing functionality via a new interface called `IHRC632`, which will act on an account address in addition to the `IHederaAccountService` interface which act on a contract address.  
+This HIP proposes adding missing functionality via a new interface called `IHRC632`, which will act on an account address, in addition to the `IHederaAccountService` interface which acts on a contract address.  
 
 
 ## User stories
@@ -41,7 +41,7 @@ This HIP proposes adding missing functionality via a new interface called `IHRC6
 
 ## Smart Contracts
 This HIP extends the functionality of the Hedera Account Service system contract by adding another related interface, `IHRC632`, to support the `hbarAllowance` and `hbarApprove` function calls to EOAs.  In addition,
-new functions will be added to the `IHederAccountService` interface to support similar calls to contracts.
+new functions will be added to the `IHederaAccountService` interface to support similar calls to contracts.
 The `hbarAllowance` function will be used to retrieve information about allowance granted to a spender and the `hbarApprove` function will allow the sender to grant to the `spender` an allowance of hbars.
 
 ## Acting on an EOA
@@ -77,56 +77,64 @@ contract Assembly {
 
 > Note: Just as with the Hedera Token Service system contract, the Hedara Account Service system contract will not be callable using `delegatecall` from a contract. 
 
-The following table describes the function selector for the new `hbarAllownace` and `hbarApprove` functions and the associated function signature and response in `IHRC632`.
+The following table describes the function selector for the new `hbarAllownace` and `hbarApprove` functions and the associated function signatures and responses in `IHRC632`.
 
-| Function Selector Hash | Function Signature                             | Response                                                                               | 
-|------------------------|------------------------------------------------|----------------------------------------------------------------------------------------|
-| 0xbbee989e             | hbarAllowance(address spender)                 | (ResponseCode, uint256 - amount of hbar allowances currently available to the spender) | 
-| 0x76f17392             | hbarApprove(address spender, uint256 amount)   | ResponseCode                                                                           |
+| Function Selector Hash | Function Signature                            | Response               | Comments                                                                                             | 
+|------------------------|-----------------------------------------------|------------------------|------------------------------------------------------------------------------------------------------|
+| 0xbbee989e             | hbarAllowance(address spender)                | (ResponseCode, int256) | The response code from the call and the amount of hbar allowances currently available to the spender | 
+| 0x86aff07c             | hbarApprove(address spender, int256 amount)   | (ResponseCode)         | The response code from the call                                                                      |
 
 The solidity interface for `IHRC632` will be the following
 
 ```
 interface IHRC632 {
     function hbarAllowance(address spender) external returns (responseCode, int256);
-    function hbarApprove(address spender, uint256 amount) external returns (responseCode);
+    function hbarApprove(address spender, int256 amount) external returns (responseCode);
 }
 ```
 
 Once the above functionality has been implemented in services, an EOA with hbars will be able to call the `hbarAllowance` and `hbarApprove` functions as follows:
 
 ```
-IHRC(accountAddress).hbarAllowance(address spender)
-IHRC(accountAddress).hbarApprove(address spender, uint256 amount)
+IHRC632(accountAddress).hbarAllowance(address spender)
+IHRC632(accountAddress).hbarApprove(address spender, int256 amount)
 ```
 > The `hbarApprove` function will be callable by an EOA as long as the signatures required by the security model are met.
 
 ## Acting on a Contract
-The `IHederaAccountService` system contract will be updated to include the `hbarAllowance` and `hbarApprove` functions.  
+The `IHederaAccountService` system contract will be updated to add the `hbarAllowance` and `hbarApprove` functions.  
 The signature of these calls will be similar to the EOA calls except that they will include the contract address as the first argument.
 
-The following table describes the function selector for the new `hbarAllownace` and `hbarApprove` functions and the associated function signature and response in `IHederaAccountService`.
+The following table describes the function selectors for the new `hbarAllownace` and `hbarApprove` functions and the associated function signatures and responses in `IHederaAccountService`.
 
-| Function Selector Hash | Function Signature                                          | Response                                                                               | 
-|------------------------|-------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| 0xfec46666             | hbarAllowance(address owner, address spender)               | (ResponseCode, uint256 - amount of hbar allowances currently available to the spender) | 
-| 0x6e0c21cc             | hbarApprove(address owner, address spender, uint256 amount) | ResponseCode                                                                           |
+| Function Selector Hash | Function Signature                                         | Response               |                                                                                                      | 
+|------------------------|------------------------------------------------------------|------------------------|------------------------------------------------------------------------------------------------------|
+| 0xfec46666             | hbarAllowance(address owner, address spender)              | (ResponseCode, int256) | The response code from the call and the amount of hbar allowances currently available to the spender | 
+| 0xa0918464             | hbarApprove(address owner, address spender, int256 amount) | ResponseCode           | The response code from the call                                                                      |
 
-The solidity interface for `IHederaAccountService` will be the following
+The solidity interface for `IHederaAccountService` will be the following after this HIP is implemented:
 
 ```
 interface IHederaAccountService {
+    ...
     function hbarAllowance(address owner, address spender) external returns (responseCode, int256);
-    function hbarApprove(address owner, address spender, uint256 amount) external returns (responseCode);
+    function hbarApprove(address owner, address spender, int256 amount) external returns (responseCode);
+    ...
 }
 ```
 
 Once the above functionality has been implemented in services, a contract with hbars will be able to call the `hbarAllowance` and `hbarApprove` functions as follows:
 
 ```
-IHederaAccountService(0x16a).hbarAllowance(address owner, address spender)
-IHederaAccountService(0x16a).hbarApprove(address owner, address spender, uint256 amount)
-```
+SampleContract is HederaAccountService {
+    function someFunction() {
+        ...    
+        this.hbarAllowance(address owner, address spender)
+        this.hbarApprove(address owner, address spender, int256 amount)
+        ...
+    }
+}
+
 > The `hbarApprove` function will be callable by a contract as long as the signatures required by the security model are met.
 
 

--- a/HIP/hip-906.md
+++ b/HIP/hip-906.md
@@ -11,7 +11,7 @@ status: Last Call
 last-call-date-time: 2024-05-01T07:00:00Z
 created: 2024-02-23
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/906
-updated: 2024-04-18
+updated: 2024-04-22
 requires: 632
 ---
 
@@ -28,10 +28,7 @@ The lack of a mechanism to grant allowance and approval for hbars without using 
 ## Rationale
 
 [HIP-632](https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-632.md) proposed to introduce a new system contract for accessing Hedera account functionality (Hedera Account Service - HAS).  
-This HIP proposes adding missing functionality via a new interface called `IHRC632`, which will act on an account address.  
-
-An alternative approach would be to introduce a new interface that a contract can implement. However, this would require deploying a contract, which may not always be desired. 
-Additionally, taking this approach could potentially violate the smart contracts security model, as the sender of the frame when executing the system contract would be the deployed contract rather than the EOA (Externally Owned Account), which would not be desirable in many cases.
+This HIP proposes adding missing functionality via a new interface called `IHRC632`, which will act on an account address in addition to the `IHederaAccountService` interface which act on a contract address.  
 
 
 ## User stories
@@ -43,10 +40,11 @@ Additionally, taking this approach could potentially violate the smart contracts
 ## Specification
 
 ## Smart Contracts
-This HIP extends the functionality of the Hedera Account Service system contract by adding another related interface `IHRC632` to support the `hbarAllowance` and `hbarApprove` functions.
+This HIP extends the functionality of the Hedera Account Service system contract by adding another related interface, `IHRC632`, to support the `hbarAllowance` and `hbarApprove` function calls to EOAs.  In addition,
+new functions will be added to the `IHederAccountService` interface to support similar calls to contracts.
 The `hbarAllowance` function will be used to retrieve information about allowance granted to a spender and the `hbarApprove` function will allow the sender to grant to the `spender` an allowance of hbars.
 
-
+## Acting on an EOA
 Similar to the way redirection to a proxy contract during EVM execution for tokens works [see HIP-719](https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-719.md),
 this HIP proposes to introduce a new proxy contract for accounts.  During EVM execution, if the target of the current frame is an account, a call to the new proxy contract will be created and the current calldata will be injected into 
 the proxy contract for processing by the Hedera Account Service system contract.
@@ -79,14 +77,14 @@ contract Assembly {
 
 > Note: Just as with the Hedera Token Service system contract, the Hedara Account Service system contract will not be callable using `delegatecall` from a contract. 
 
-The following table describes the function selector for the new `hbarAllownace` and `hbarApprove` functions and the associated function signature and response.
+The following table describes the function selector for the new `hbarAllownace` and `hbarApprove` functions and the associated function signature and response in `IHRC632`.
 
 | Function Selector Hash | Function Signature                             | Response                                                                               | 
 |------------------------|------------------------------------------------|----------------------------------------------------------------------------------------|
 | 0xbbee989e             | hbarAllowance(address spender)                 | (ResponseCode, uint256 - amount of hbar allowances currently available to the spender) | 
 | 0x76f17392             | hbarApprove(address spender, uint256 amount)   | ResponseCode                                                                           |
 
-The solidity interface for IHRC632 will be the following
+The solidity interface for `IHRC632` will be the following
 
 ```
 interface IHRC632 {
@@ -95,13 +93,42 @@ interface IHRC632 {
 }
 ```
 
-Once the above functionality has been implemented in services, an EOA or contract with hbars will be able to call the `hbarAllowance` and `hbarApprove` functions as follows:
+Once the above functionality has been implemented in services, an EOA with hbars will be able to call the `hbarAllowance` and `hbarApprove` functions as follows:
 
 ```
 IHRC(accountAddress).hbarAllowance(address spender)
 IHRC(accountAddress).hbarApprove(address spender, uint256 amount)
 ```
-> The `hbarApprove` function will be callable by either an EOA or a contract as long as the signatures required by the security model are met.
+> The `hbarApprove` function will be callable by an EOA as long as the signatures required by the security model are met.
+
+## Acting on a Contract
+The `IHederaAccountService` system contract will be updated to include the `hbarAllowance` and `hbarApprove` functions.  
+The signature of these calls will be similar to the EOA calls except that they will include the contract address as the first argument.
+
+The following table describes the function selector for the new `hbarAllownace` and `hbarApprove` functions and the associated function signature and response in `IHederaAccountService`.
+
+| Function Selector Hash | Function Signature                                          | Response                                                                               | 
+|------------------------|-------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| 0xfec46666             | hbarAllowance(address owner, address spender)               | (ResponseCode, uint256 - amount of hbar allowances currently available to the spender) | 
+| 0x6e0c21cc             | hbarApprove(address owner, address spender, uint256 amount) | ResponseCode                                                                           |
+
+The solidity interface for `IHederaAccountService` will be the following
+
+```
+interface IHederaAccountService {
+    function hbarAllowance(address owner, address spender) external returns (responseCode, int256);
+    function hbarApprove(address owner, address spender, uint256 amount) external returns (responseCode);
+}
+```
+
+Once the above functionality has been implemented in services, a contract with hbars will be able to call the `hbarAllowance` and `hbarApprove` functions as follows:
+
+```
+IHederaAccountService(0x16a).hbarAllowance(address owner, address spender)
+IHederaAccountService(0x16a).hbarApprove(address owner, address spender, uint256 amount)
+```
+> The `hbarApprove` function will be callable by a contract as long as the signatures required by the security model are met.
+
 
 ## Key Benefits and Possible Use Cases
 Key benefits include:
@@ -137,12 +164,8 @@ when implementing this functionality.  Thorough testing will be required to ensu
 
 ## How to Teach This
 
-The `hbarAllowance` and `hbarApprove` functions can be accessed by an EOA or a contract by calling the `IHRC632` interface as described above.  This enhances the functionality and use cases
-available to the smart contract developer.
-
-## Rejected Ideas
-
-The idea of introducing this functionality to the IHederaAccountService interface directly was discarded as this would require that a contract be deployed which may not always be desired.  Due to security considerations, doing so would make the functionality less than useful.
+The `hbarAllowance` and `hbarApprove` functions can be accessed by an EOA by calling the `IHRC632` interface as described above.  In addition, these calls will be accessible 
+to contracts by the additions to the `IHederaAccountService` interface.  This enhances the functionality and use cases available to the smart contract developer.
 
 ## Open Issues
 

--- a/HIP/hip-906.md
+++ b/HIP/hip-906.md
@@ -77,7 +77,7 @@ contract Assembly {
 
 > Note: Just as with the Hedera Token Service system contract, the Hedara Account Service system contract will not be callable using `delegatecall` from a contract. 
 
-The following table describes the function selector for the new `hbarAllownace` and `hbarApprove` functions and the associated function signatures and responses in `IHRC632`.
+The following table describes the function selector for the new `hbarAllowance` and `hbarApprove` functions and the associated function signatures and responses in `IHRC632`.
 
 | Function Selector Hash | Function Signature                            | Response               | Comments                                                                                             | 
 |------------------------|-----------------------------------------------|------------------------|------------------------------------------------------------------------------------------------------|
@@ -96,8 +96,8 @@ interface IHRC632 {
 Once the above functionality has been implemented in services, an EOA with hbars will be able to call the `hbarAllowance` and `hbarApprove` functions as follows:
 
 ```
-IHRC632(accountAddress).hbarAllowance(address spender)
-IHRC632(accountAddress).hbarApprove(address spender, int256 amount)
+IHRC632(accountAddress).hbarAllowance(spender)
+IHRC632(accountAddress).hbarApprove(spender, amount)
 ```
 > The `hbarApprove` function will be callable by an EOA as long as the signatures required by the security model are met.
 
@@ -105,7 +105,7 @@ IHRC632(accountAddress).hbarApprove(address spender, int256 amount)
 The `IHederaAccountService` system contract will be updated to add the `hbarAllowance` and `hbarApprove` functions.  
 The signature of these calls will be similar to the EOA calls except that they will include the contract address as the first argument.
 
-The following table describes the function selectors for the new `hbarAllownace` and `hbarApprove` functions and the associated function signatures and responses in `IHederaAccountService`.
+The following table describes the function selectors for the new `hbarAllowance` and `hbarApprove` functions and the associated function signatures and responses in `IHederaAccountService`.
 
 | Function Selector Hash | Function Signature                                         | Response               |                                                                                                      | 
 |------------------------|------------------------------------------------------------|------------------------|------------------------------------------------------------------------------------------------------|
@@ -129,8 +129,8 @@ Once the above functionality has been implemented in services, a contract with h
 SampleContract is HederaAccountService {
     function someFunction() {
         ...    
-        this.hbarAllowance(address owner, address spender)
-        this.hbarApprove(address owner, address spender, int256 amount)
+        this.hbarAllowance(owner, spender)
+        this.hbarApprove(owner, spender, amount)
         ...
     }
 }


### PR DESCRIPTION
The original HIP was not clear on the distinction between how calls when acting on an EOA differs from calls when acting on a contract.  
