### PR TITLE
Update hip-765.md

### DIFF
--- a/HIP/hip-765.md
+++ b/HIP/hip-765.md
@@ -66,7 +66,7 @@ message TokenCreateTransactionBody {
 2. Permit updates by adding a new field to [`TokenUpdateTransactionBody`](https://github.com/hashgraph/hedera-protobufs/blob/main/services/token_update.proto),
 Property `metadata` is set at the **token-type** level for non-fungible tokenID.
 
-**Updating the metadata field should require a metadataKey (ie [HIP-657](https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-657.md))**
+**Updating the metadata field requires the metadataKey or adminKey to sign the transaction (ie [HIP-657](https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-657.md))**
 
 ```
 message TokenUpdateTransactionBody {

--- a/HIP/hip-765.md
+++ b/HIP/hip-765.md
@@ -10,7 +10,8 @@ status: Accepted
 last-call-date-time: 2023-07-28T07:00:00Z
 created: 2023-07-11
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/765
-updated: 2024-02-02
+updated: 2024-02-02, 2024-04-24
+requested-by: NA
 ---
 
 ## Abstract


### PR DESCRIPTION
- This HIP did not call out that the `adminKey` can also sign the `TokenUpdateTransaction` to modify the `metadata` field on a NFT collection.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
