### PR TITLE
Add Timestamp to Mirror Node REST API Response

### DIFF
--- a/HIP/hip-904.md
+++ b/HIP/hip-904.md
@@ -1011,14 +1011,22 @@ The SDKs must update the `TransactionRecord` to return the following information
                     "amount": 333,
                     "receiver_id": "0.0.999",
                     "sender_id": "0.0.222",
-                                "serial_number": null,
+                    "serial_number": null,
+                    "timestamp": {
+                       "from": "1111111111.111111111",
+                       "to": null
+                    },
                     "token_id": "0.0.111"
                 },
                 {
                     "amount": 555,
                     "receiver_id": "0.0.999",
                     "sender_id": "0.0.222",
-                                "serial_number": null,
+                    "serial_number": null,
+                    "timestamp": {
+                       "from": "1111111111.111111112",
+                       "to": null
+                    },
                     "token_id": "0.0.444"
                 },
                 {
@@ -1026,6 +1034,10 @@ The SDKs must update the `TransactionRecord` to return the following information
                     "receiver_id": "0.0.999",
                     "sender_id": "0.0.222",
                     "serial_number": 888,
+                    "timestamp": {
+                       "from": "1111111111.111111113",
+                       "to": null
+                    },
                     "token_id": "0.0.666"
                 }
             ],
@@ -1055,6 +1067,10 @@ The SDKs must update the `TransactionRecord` to return the following information
                     "receiver_id": "0.0.999",
                     "sender_id": "0.0.222",
                     "serial_number": null,
+                    "timestamp": {
+                       "from": "1111111111.111111111",
+                       "to": null
+                    },
                     "token_id": "0.0.111"
                 },
                 {
@@ -1062,6 +1078,10 @@ The SDKs must update the `TransactionRecord` to return the following information
                     "receiver_id": "0.0.999",
                     "sender_id": "0.0.222",
                     "serial_number": null,
+                    "timestamp": {
+                       "from": "1111111111.111111112",
+                       "to": null
+                    },
                     "token_id": "0.0.444"
                 },
                 {
@@ -1069,6 +1089,10 @@ The SDKs must update the `TransactionRecord` to return the following information
                     "receiver_id": "0.0.999",
                     "sender_id": "0.0.222",
                     "serial_number": 888,
+                    "timestamp": {
+                       "from": "1111111111.111111113",
+                       "to": null
+                    },
                     "token_id": "0.0.666"
                 }
             ],

--- a/HIP/hip-904.md
+++ b/HIP/hip-904.md
@@ -11,7 +11,7 @@ status: Accepted
 last-call-date-time: 2024-04-08T07:00:00Z
 created: 2024-02-25
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/905
-updated: 2024-04-17
+updated: 2024-05-06
 replaces: 655, 777
 ---
 


### PR DESCRIPTION
**Description**:
Per discussion on the MIrror Node Frictionless Airdrops design document (https://github.com/hashgraph/hedera-mirror-node/pull/8127), this PR updates the Mirror Node REST API to include the timestamp field. 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
