### PR TITLE
Update mirror node release number and status

### DIFF
--- a/HIP/hip-171.md
+++ b/HIP/hip-171.md
@@ -6,10 +6,11 @@ type: Standards Track
 category: Mirror
 needs-council-approval: Yes
 status: Final
+release: v0.49.0
 last-call-date-time: 2021-11-23T07:00:00Z
 created: 2021-10-18
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/190
-updated: 2022-04-26
+updated: 2024-05-14
 ---
 
 ## Abstract

--- a/HIP/hip-21.md
+++ b/HIP/hip-21.md
@@ -7,10 +7,10 @@ category: Mirror
 needs-council-approval: Yes
 status: Final
 last-call-date-time: 2021-11-30T07:00:00Z
-release: v0.22.0
+release: v0.54.0
 created: 2021-06-09 
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/82
-updated: 2022-04-26
+updated: 2024-05-14
 ---
 
 ## Abstract

--- a/HIP/hip-331.md
+++ b/HIP/hip-331.md
@@ -7,10 +7,10 @@ category: Mirror
 needs-council-approval: Yes
 status: Final
 last-call-date-time: 2022-02-04T07:00:00Z
-release: v0.51.0
+release: v0.52.0
 created: 2021-01-21
 discussions-to: https://github.com/hashgraph/hedera-mirror-node/issues/3081
-updated: 2023-02-01
+updated: 2024-05-14
 ---
 
 ## Abstract

--- a/HIP/hip-801.md
+++ b/HIP/hip-801.md
@@ -5,12 +5,12 @@ author: Ivan Kavaldzhiev <ivan.kavaldzhiev@limechain.tech>, Stoyan Panayotov <st
 working-group: Steven Sheehy <steven.sheehy@swirldslabs.com>, Nana Essilfie-Conduah <nana@swirldslabs.com>, Danno Ferrin <danno.ferrin@swirldslabs.com>, David Bakin <david.bakin@swirldslabs.com>, Georgi Lazarov <georgi.lazarov@limechain.tech>
 type: Standards Track
 needs-council-approval: No
-category: Service
+category: Mirror
 status: Accepted
 last-call-date-time: 2024-01-10T07:00:00Z
 created: 2023-08-31
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/802
-updated: 2024-01-24
+updated: 2024-05-14
 ---
 
 ## Abstract

--- a/HIP/hip-857.md
+++ b/HIP/hip-857.md
@@ -7,11 +7,12 @@ requested-by: Hashpack and Zuse Marketplace
 type: Standards Track
 category: Mirror
 needs-council-approval: Yes
-status: Accepted
+status: Final
+release: v0.106.0
 last-call-date-time: 2024-02-01T07:00:00Z
 created: 2023-12-07
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/858
-updated: 2024-02-15
+updated: 2024-05-14
 ---
 
 ## Abstract

--- a/HIP/hip-859.md
+++ b/HIP/hip-859.md
@@ -7,11 +7,12 @@ requested-by: Supra Oracle
 type: Standards Track
 category: Mirror
 needs-council-approval: Yes
-status: Accepted
+status: Final
+release: v0.100.0
 last-call-date-time: 2024-02-08T07:00:00Z
 created: 2024-01-17
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/860
-updated: 2024-02-21
+updated: 2024-05-14
 ---
 
 ## Abstract

--- a/HIP/hip-873.md
+++ b/HIP/hip-873.md
@@ -6,11 +6,12 @@ requested-by: Atlantis
 type: Standards Track
 category: Mirror
 needs-council-approval: Yes
-status: Accepted
+status: Final
+release: v0.99.0
 last-call-date-time: 2024-02-14T07:00:00Z
 created: 2024-01-30
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/873
-updated: 2024-02-15
+updated: 2024-05-14
 ---
 
 ### Abstract


### PR DESCRIPTION
**Description**:

Updates multiple mirror node HIPs to provide accurate release numbers and move them to Final status if they're in production.

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
