### PR TITLE
fix: HIP-540: clarify that an admin key cannot be set to "unusable" key value

### DIFF
--- a/HIP/hip-540.md
+++ b/HIP/hip-540.md
@@ -90,7 +90,7 @@ First, let's address important language to set a clear distinction between "remo
 ## Specification
 
 1. Only the admin key should be able to remove itself or other keys.
-2. All keys can change themselves to another valid or unusable key (such as all-zeros).
+2. All keys can change themselves to another valid or unusable key (such as all-zeros). Except for the admin key - we do not support setting an unusable admin key. This is because removing the admin key and making it unusable are functionally identical. It should simply be removed if no longer desired.
 
 ### Other Considerations
 

--- a/HIP/hip-540.md
+++ b/HIP/hip-540.md
@@ -11,7 +11,7 @@ status: Accepted
 last-call-date-time: 2023-07-03T07:00:00Z
 created: 2022-08-05
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/522
-updated: 2024-04-26
+updated: 2024-05-15
 ---
 
 ## Abstract


### PR DESCRIPTION
**Description**:
Currently, as stated in the HIP-540 document, a token `adminKey` can be removed and also it can change itself to `0x00..000` (or the so-called "unusable" key value). Those two different possibilities essentially have the same final result:
- The token will never again have a usable `adminKey`

@tinker-michaelj @netopyr 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Make it clear that a token `adminKey` can **only** be removed and cannot be set to "unusable" key, despite the value of the `keyVerificationMode`

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
