### PR TITLE
fix: Fix description of authorization of Hedera account

### DIFF
--- a/HIP/hip-632.md
+++ b/HIP/hip-632.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-01-10T07:00:00Z
 created: 2022-11-28
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/638
-updated: 2022-12-13, 2022-12-20, 2023-01-03, 2023-01-18
+updated: 2024-05-22
 requires: 631
 ---
 


### PR DESCRIPTION
**Description**:

Description of how `isAuthorizedRaw` handles an ED signature for a Hedera account is just wrong: Nothing is signed, a signature is verifed as usual.
* (Nothing _can_ be signed: Hedera doesn't have any private keys in state to sign anything _with_.)

