### PR TITLE
Update status of HIP-874 for mirror node release 0.106.0.

### DIFF
--- a/HIP/hip-874.md
+++ b/HIP/hip-874.md
@@ -4,13 +4,14 @@ title: Enhancing Topic Metadata Accessibility in the Hedera REST API
 author: Michael Kantor (@kantorcodes), Ty Smith (@ty-swirldslabs)
 type: Standards Track
 category: Mirror
-status: Accepted
+status: Final
+release: v0.106.0
 last-call-date-time: 2024-03-27T07:00:00Z
 created: 2024-02-14
 requested-by: TierBot
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/883
 needs-council-approval: Yes
-updated: 2024-04-08
+updated: 2024-06-13
 ---
 
 ## Abstract:


### PR DESCRIPTION
**Description**:

With today's release of mirror node v0.106.1. to mainnet, HIP-874 is now final and in production.

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
