### PR TITLE
Add clarification around auto associations and token reject

### DIFF
--- a/HIP/hip-904.md
+++ b/HIP/hip-904.md
@@ -11,7 +11,7 @@ status: Accepted
 last-call-date-time: 2024-04-08T07:00:00Z
 created: 2024-02-25
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/905
-updated: 2024-06-26
+updated: 2024-07-01
 replaces: 655, 777
 ---
 
@@ -39,7 +39,7 @@ In summary
 - Token senders may avoid errors on airdrop transfer attempts by utilizing the `TokenAirdrop` transaction.
 - Intended airdrop receiver accounts can choose to accept a token airdrop by utilizing the `TokenClaimAirdrop` transaction.
 - Airdrop sender accounts can change their mind and cancel a pending airdrop transfer by utilizing the `TokenCancelAirdrop` transaction.
-- Token holders can get rid of unwanted tokens without paying exorbitant and potentially malicious fees regardless of how they acquired the token (manual or automatic association) by utilizing the `TokenReject` transaction.
+- Token holders can get rid of unwanted tokens without paying exorbitant and potentially malicious fees regardless of how they acquired the token (manual or automatic association) by utilizing the `TokenReject` transaction, except where token freeze or pause status are in effect.
 
 ## Motivation
 
@@ -139,6 +139,13 @@ This HIP changes this behavior in the following ways:
   will continue to have a `max_auto_associations` default of 0. Accounts created before this feature
   is released will remain unchanged.
 
+> ⚠️ Currently `max_auto_associations` designates an accounts openness to automatically associate with a token
+regardless of its properties e.g freeze or pause token properties. This scope is too broad for some cases and 
+may change in future. A future HIP may describe how it is possible to refine `max_auto_associations` and narrow
+the definition to specify when an account does not want to auto associate if the token has a freeze or pause key.
+Accounts are encouraged to be observant if they want to associate with a token that has a freeze or pause key.
+Wallets and explorers are also encouraged to highlight such token properties to users for awareness.
+
 ### Crypto Transfers
 
 Normal crypto-transfers remain the same as today, with one difference. If Account A sends a token to
@@ -148,6 +155,8 @@ addition to the typical transfer costs. In summary previously the receiver would
 association in advance, not the payer of the transaction.
 
 ![Crypto Transfer Transaction](../assets/hip-904/frictionless-airdrop-cryptoTransferTransaction.png)
+
+> ⚠️ A consensus node will now output a preceding TokenAssociate record when a user is automatically associated.
 
 ### Airdrops
 
@@ -208,7 +217,9 @@ introduced. When a receiver claims a token, the `TokenClaimAirdrop` transaction 
 the receiver, in addition to the transaction payer (who may be the same as the receiver). In
 essence, if an account has no free auto-association slots, then it behaves as though
 receiver-sig-required were true *for airdrops*. That is, the receiver must sign the transaction to
-receive the airdrop.
+receive the airdrop. 
+This transaction also serves as an explicit desire to assocaite with the token, as such the `TokenClaim`
+transaction record may be processed as the equivalent of a `TokenAssociate` and a `CryptoTransfer`.
 
 ![Token Claim Airdrop Transaction](../assets/hip-904/frictionless-airdrop-tokenClaim.png)
 
@@ -268,7 +279,7 @@ will only pay the appropriate fees for the HAPI transaction type.
 > ⚠️ `receiver_sig_required` is ignored on the treasury account when the `TokenReject` is handled.
 > Reject will always work with no assessed custom fees.
 
-> ⚠️ Token rejection is not supported if a token is frozen or paused.
+> ⚠️ Token rejection is not supported if a token is frozen or an account is paused on the token.
 
 ### Example
 
@@ -1307,6 +1318,7 @@ properties and provide easy management functionality. Explorers may consider
   potential recipients if the sender has the balance to support the pending transfer
 - supporting the ability to execute `TokenClaim` transaction via multiple wallets
 - supporting the ability to execute `TokenReject` transaction via multiple wallets
+- Educational tool tips around the presence of a freeze or pause key on a token and its impact to a user.
 
 ### Wallets consideration
 
@@ -1325,6 +1337,7 @@ Wallet software should:
 - expose outstanding airdrops for which an account has sent that have yet to be claimed.
 - Educational tool tips around pending transfer logic to help educate users. Especially noting
   pending is not guaranteed
+- Educational tool tips around the presence of a freeze or pause key on a token and its impact to a user.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
**Description**:
The implementation of HIP 904 has highlighted certain details that are worthwhile being more explicit on
- Highlight preceding TokenAssociate transaction record 
- Add note about potential future change to maxAutoAssociaton feature 
- Emphasize token reject non applicability when token is frozen or account is paused

**Related issue(s)**:

Fixes #

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
