### PR TITLE
Updated discord-action to use step-security maintained version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/devops-ci
+/.github/workflows/                             @hashgraph/devops-ci @devops-ci-committers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                      @hashgraph/release-engineering-managers

--- a/.github/workflows/send-discord-message.yml
+++ b/.github/workflows/send-discord-message.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD }}
-        uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9 # v0.3.2
+        uses: step-security/action-discord@a67f622d551a2f5fcc316c78e0076fe665ff6637 # v0.1.0
         with:
           args:  "${{ github.event.inputs.filename }} moved into ${{ github.event.inputs.status }} status https://hips.hedera.com/hip/${{ github.event.inputs.filename }}"


### PR DESCRIPTION
## Background

Step-security is maintaining a list of actions with low scores. We need to update our third party actions to use
only actions with high scores. Step-security is now maintaining forked versions of utilized actions that should
be used. This story intends to update the actions listed below in [Step-Security Actions](#step-security-actions).

## Step-Security Action(s)

Update github actions with step-security maintained version

- [x] Original Action: [Ilshidur/action-discord](https://app.stepsecurity.io/github/hashgraph/actions/action-details/Ilshidur%2Faction-discord) - Step Security Maintained Action: [step-security/action-discord](https://github.com/step-security/action-discord)

## Acceptance Criteria

- [x] All required actions have been updated