### PR TITLE
docs: Update HIP-32 to note removal of ability to set account's alias with an update

### DIFF
--- a/HIP/hip-32.md
+++ b/HIP/hip-32.md
@@ -57,7 +57,7 @@ An automatically-created account will be created with only one public key (the o
 
 At most one account can ever have a given alias. If a transaction auto-creates the account, any further transfers to that alias will simply be deposited in that account, without creating anything, and with no creation fee being charged.
 
-~~An account created normally has no alias. It can be given an alias with an account update, but only if that alias is not currently used by any other account, and only if the update transaction is signed by the private key corresponding to the public key in the alias.~~
+An account created normally has no alias. ~~It can be given an alias with an account update, but only if that alias is not currently used by any other account, and only if the update transaction is signed by the private key corresponding to the public key in the alias.~~
 * **UPDATE:** This ability has been removed by [HIP-583](https://hips.hedera.com/hip/hip-583#update-account-with-alias),
 which provides other ways to set the alias.
 

--- a/HIP/hip-32.md
+++ b/HIP/hip-32.md
@@ -10,7 +10,7 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discuss
 last-call-date-time: 2021-12-03T07:00:00Z
 release: v0.21.0
 created: 2021-11-01
-updated: 2022-04-26
+updated: 2024-07-24
 requires: 15
 ---
 
@@ -57,7 +57,9 @@ An automatically-created account will be created with only one public key (the o
 
 At most one account can ever have a given alias. If a transaction auto-creates the account, any further transfers to that alias will simply be deposited in that account, without creating anything, and with no creation fee being charged.
 
-An account created normally has no alias. It can be given an alias with an account update, but only if that alias is not currently used by any other account, and only if the update transaction is signed by the private key corresponding to the public key in the alias.
+~~An account created normally has no alias. It can be given an alias with an account update, but only if that alias is not currently used by any other account, and only if the update transaction is signed by the private key corresponding to the public key in the alias.~~
+* **UPDATE:** This ability has been removed by [HIP-583](https://hips.hedera.com/hip/hip-583#update-account-with-alias),
+which provides other ways to set the alias.
 
 Once an account has an alias, the alias can never be changed, and can never be associated with any other account until the first account is deleted and removed from the ledger. Only then could another account be created or updated to be associated with that alias.
 
@@ -98,6 +100,8 @@ From the user's point of view, these virtual "accounts" should be indistinguisha
 ## Open Issues
 
 ## References
+
+* [HIP-583](https://hips.hedera.com/hip/hip-583) - "Expand alias support in CryptoCreate & CryptoTransfer Transactions"
 
 ## Copyright/license
 This document is licensed under the Apache License, Version 2.0 -- see LICENSE or (https://www.apache.org/licenses/LICENSE-2.0)

--- a/HIP/hip-32.md
+++ b/HIP/hip-32.md
@@ -58,7 +58,7 @@ An automatically-created account will be created with only one public key (the o
 At most one account can ever have a given alias. If a transaction auto-creates the account, any further transfers to that alias will simply be deposited in that account, without creating anything, and with no creation fee being charged.
 
 An account created normally has no alias. ~~It can be given an alias with an account update, but only if that alias is not currently used by any other account, and only if the update transaction is signed by the private key corresponding to the public key in the alias.~~
-* **UPDATE:** This ability has been removed by [HIP-583](https://hips.hedera.com/hip/hip-583#update-account-with-alias),
+* **UPDATE:** This intent has been revisited and retracted by [HIP-583](https://hips.hedera.com/hip/hip-583#update-account-with-alias),
 which provides other ways to set the alias.
 
 Once an account has an alias, the alias can never be changed, and can never be associated with any other account until the first account is deleted and removed from the ledger. Only then could another account be created or updated to be associated with that alias.

--- a/HIP/hip-632.md
+++ b/HIP/hip-632.md
@@ -63,7 +63,7 @@ This function is similar to using the ECRECOVER precompile function.  Ethereum u
     * If true, extract v, r and s and run ECRECOVER(messageHash, v, r, s) and determine if the result matches any of the virtual address on the account.  Return true if any matching address is found if given a Hedera Account ID. If given an Ethereum address, the recovered address must match the given address.
 3. If length of signatureBlob is 64 bytes in length
     * Retrieve the Hedera address. Determine if there is a single key associated with the Hedera Accound ID.  If not return false.
-    * If there is a single key, sign the messageHash and return true if the signature matches the signatureBlob.  
+    * If there is a single key, verify that the signature (the signatureBlob) signs the message hash and is attested by the account.
 
 ### `isAuthorized(address, messageHash, signatureBlob)` Function Usage
 This function is used for Hedera account (non Ethereum) signature validation.  It handles the more complex signature types which are available with Hedera accounts.  One or more signatures will be encoded in protobuf format into the signatureBlob.  The precompile function will look up the keys for the account and determine if the signatures passed in via the signatureBlob satisfy the signing requirements for the account.  For example, if the account has a threshhold key of needing 3 out of 4 signatures,the precompile function will sign the messageHash with each key on the account and determine if at least 3 signatures in the signatureBlob matches.

--- a/HIP/hip-632.md
+++ b/HIP/hip-632.md
@@ -10,7 +10,7 @@ status: Accepted
 last-call-date-time: 2023-01-10T07:00:00Z
 created: 2022-11-28
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/638
-updated: 2022-12-13, 2022-12-20, 2023-01-03, 2023-01-18
+updated: 2024-05-22
 requires: 631
 ---
 


### PR DESCRIPTION
**Description**:

Update HIP-32 to note removal of ability to set account's alias with an update

Refers to the section of HIP-583 that does this.
