### PR TITLE
Improvements to HIP-991

### DIFF
--- a/HIP/hip-991.md
+++ b/HIP/hip-991.md
@@ -10,7 +10,7 @@ status: Council Review
 last-call-date-time: 2024-07-24T07:00:00Z
 created: 2024-06-14
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/991
-updated: 2024-07-30
+updated: 2024-08-05
 ---
 
 ## Abstract
@@ -71,7 +71,9 @@ We propose adding a fixed fee mechanism to the Hedera Consensus Service (HCS) fo
 
 * Topics can have a Fee Schedule Key set at creation time.
 * Fee Schedule Key can manage fee updates and send free messages to the topic.
-* The Fee Schedule Key can be updated with an update topic transaction signed by the Admin Key and the new Fee Schedule Key.
+* Fee Schedule Key follows the same "Lower privilege key" rules introduced by [HIP-540](https://hips.hedera.com/hip/hip-540), that means:
+  * Only the admin key should be able to remove the Fee Schedule Key.
+  * Fee Schedule Key can change itself to another valid or unusable key.
 * If the topic was created without a Fee Schedule Key, the key cannot be added later.
 * Topics can have fees for submitting messages.
 * Fees can be set at creation time.

--- a/HIP/hip-991.md
+++ b/HIP/hip-991.md
@@ -13,11 +13,11 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/99
 updated: 2024-07-24
 ---
 
-## **Abstract**
+## Abstract
 
 This document outlines the development of a fixed fee system for the submission of topic messages on the Hedera network. It addresses the need for improved economic scalability and aims to enhance resource allocation and revenue distribution mechanisms for topic operators. It also seeks to simplify engineering complexity for dApp developers on the Hedera network.
 
-## **Background and Motivation**
+## Background and Motivation
 
 **Problems to Solve:**
 
@@ -25,8 +25,6 @@ This document outlines the development of a fixed fee system for the submission 
 * **Ease of Monetization:** Developers and businesses find it challenging to charge users for submitting information to a topic due to the lack of a native fee structure. A built-in payment system would streamline monetization, allowing developers to easily charge for topic submissions, which can enhance the financial viability of their applications.
 * **Resource Allocation:** The current low fee of $0.0001 per message makes it difficult for topic operators to manage and predict the economic impact of high-traffic topics. Users can suffer from spam and unexpected messages that operators have to handle, potentially degrading the quality of service.
 * **Token and HBAR Utilization:** There is an opportunity to expand the utility of various tokens within the Hedera ecosystem. By allowing fees to be paid in tokens other than HBAR, such as those required by DAOs, users can leverage their token holdings for topic submissions, enhancing the ecosystem's flexibility and user engagement.
-
----
 
 **Feature Summary:**
 
@@ -44,150 +42,11 @@ This document outlines the development of a fixed fee system for the submission 
 * Increases revenue streams for node operators.
 * Enables simple facilitation of holding and spending tokens to document new information on a topic.
 
-**Related Requests:** This enhancement is in response to community feedback (Tier Bot) requesting more versatile and predictable economic models within topic IDs on the Hedera network.
+**Related Requests:**
 
-## **Specification**
+This enhancement is in response to community feedback (Tier Bot) requesting more versatile and predictable economic models within topic IDs on the Hedera network.
 
-### **Conceptual Overview**
-
-We propose adding a fixed fee mechanism to the Hedera Consensus Service (HCS) for topic messages, similar to the custom fee structures in the Hedera Token Service (HTS). This will involve creating new Protobuf messages and modifying existing ones to accommodate fixed fees for topics.
-
-### **Protobuf Messages Needed**
-
-### **FixedFee**
-
-The `FixedFee` message represents a fixed fee charged for each message submission to a topic. This protobuf message already exists so it can be re-used.
-
-```
-message FixedFee {
-  // The number of units to assess as a fee
-  int64 amount = 1;
-  // The denomination of the fee; taken as hbar if left unset
-  TokenID denominating_token_id = 2;
-}
-```
-
-### **CustomFixedFee**
-
-The `CustomFixedFee` message defines the type of fee and the account receiving the fee assessed during a message submission to the associated topic. A custom fee may only be fixed and must specify a fee collector account to receive the assessed fees.
-
-```
-message CustomFixedFee {
-  // Fixed fee to be charged
-  FixedFee fixed_fee = 1;
-
-  // The account to receive the custom fee
-  AccountID fee_collector_account_id = 3;
-}
-```
-
-### **Modified Protobuf Messages**
-
-### **TopicCreateTransactionBody**
-
-The `TopicCreateTransactionBody` message is updated to include an optional `custom_fees` property for specifying fixed fees during topic creation.
-
-```
-message TopicCreateTransactionBody {
-  // The ID of the topic to be created
-  TopicID topic_id = 1;
-  // The custom fees to be assessed during a message submission to this topic
-  repeated CustomFee custom_fees = 2;
-}
-```
-
-### **TopicInfo**
-
-The `TopicInfo` message is updated to include the current list of custom fixed fees associated with the topic.
-
-```
-message TopicInfo {
-  // The ID of the topic
-  TopicID topic_id = 1;
-  // The custom fees to be assessed during a message submission to this topic
-  repeated CustomFee custom_fees = 2;
-}
-```
-
-### **TransactionRecord**
-
-The `TransactionRecord` message is updated to include the list of custom fees assessed as part of executing the transaction represented by this record. This protobuf message already exists so it can be re-used.
-
-```
-message TransactionRecord {
-  // All custom fees that were assessed during a message submission
-  repeated AssessedCustomFee assessed_custom_fees = 13;
-}
-```
-
-### **New gRPC Service Methods**
-
-### **TopicService**
-
-Updates to the `TopicService` to include methods for creating topics with custom fees and updating the fee schedule for a given topic.
-
-```
-service TopicService {
-  // Creates a new topic with optional custom fees
-  rpc createTopic (Transaction) returns (TransactionResponse);
-  // Updates the custom fee schedule for a topic
-  rpc updateTopicFeeSchedule (Transaction) returns (TransactionResponse);
-}
-```
-
-### **Example Implementations**
-
-Below is an example of creating a topic with a fixed fee.
-
-```
-const { Client, TopicCreateTransaction, CustomFee, CustomFixedFee, Hbar, AccountId, TokenId, PrivateKey } = require("@hashgraph/sdk");
-
-// Create the Hedera client
-const client = Client.forTestnet();
-
-// Define the submit key
-const submitKey = PrivateKey.generate();
-
-// Define the fee collector account ID
-const feeCollectorAccountId = AccountId.fromString("0.0.12345");
-
-// Define the fixed fee
-const customFee = new CustomFixedFee()
-    .setAmount(100)
-    .setDenominatingTokenId(TokenId.fromString("0.0.56789")); // Optional, HBAR if unset
-
-// Create the topic with the custom fee
-const transaction = await new TopicCreateTransaction()
-    .setTopicMemo("Example Topic with Fixed Fee")
-    .setSubmitKey(submitKey)
-    .setCustomFees([customFee])
-    .execute(client);
-
-console.log(`Created topic with ID: ${transaction.topicId}`);
-```
-
-This implementation shows the creation of a topic where each message submission requires a fixed fee of 100 HBAR, collected by the specified account.
-
-### **Backwards Compatibility**
-
-There are no known backwards compatibility issues. Existing topics without custom fees will continue to function as they currently do. New topics with custom fees will require appropriate updates to the Hedera SDKs, mirror nodes, and applications to support the new fee structures.
-
-
-### **Security Implications**
-
-The introduction of custom fees adds an additional layer of economic control but also introduces potential vectors for abuse, such as fee manipulation.
-
-
-### **Backwards Compatibility**
-
-There are no known backwards compatibility issues. Existing topics without custom fees will continue to function as they currently do. New topics with custom fees will require appropriate updates to the Hedera SDKs, mirror nodes, and applications to support the new fee structures.
-
-
-### **Security Implications**
-
-The introduction of custom fees adds an additional layer of economic control but also introduces potential vectors for abuse, such as fee manipulation.
-
-**User Personas and Stories**
+## User personas and stories
 
 **User Personas:**
 
@@ -200,26 +59,128 @@ The introduction of custom fees adds an additional layer of economic control but
 * As a **Topic Operator**, I want to set a fixed fee for submitting messages to my topic, so that I can ensure a consistent revenue stream and manage my topic effectively.
 * As a **Regular User**, I want to know the exact cost of interacting with a topic.
 
+## Specification
 
-## **Requirements and Scope**
+### Overview
+
+We propose adding a fixed fee mechanism to the Hedera Consensus Service (HCS) for topic messages, similar to the custom fee structures in the Hedera Token Service (HTS). This will involve creating new protocol buffers (protobuf) messages and modifying existing ones to accommodate fixed fees for topics.
+
+### Requirements and Scope
 
 * Implementation of an optional custom fee key on a topic ID during topic creation.
-* Requirement for users to submit HBAR equivalent to the fee for message submissions.
+* Requirement for users to allow HBAR or Tokens to be used to pay fees for message submissions, on an HCS topic bases.
 * Exemption from fees for users with a submit key (if a submit key is also present on the topic).
 * Distribution of collected fees akin to fixed fees on tokens, with support for distribution to multiple wallets, specified percentages.
-* Exploration of using fungible tokens in addition to HBAR for fee payments.
 * Ensuring compatibility and integration with existing Hedera network protocols and services.
 
-
-## **User Flows and Interaction**
+### User Flows and Interaction
 
 * Users will specify the fee settings during the topic creation process through a simple interface in their Hedera client (refer to the creation of token custom fees/fixed fee for reference).
 * On submitting a message to a topic through a application or wallet interface, users will see the required fee and have the option to proceed or cancel.
 * Operators will get fee collections and distributions automatically through the custom fees just like they do in the token service currently.
 
-
-## **Data Sharing, Privacy, and Security**
+### Data Sharing, Privacy, and Security
 
 * Adherence to Hedera’s existing data privacy standards, ensuring that user identities and transaction details remain protected.
 * Implementation of security measures to prevent unauthorized access to fee configurations and distributions.
 * Callout on the HIP that when programmatically connecting to topics that have a custom fee key enabled, to set max fee on transactions so that if the fee is changed to be higher per message submission, the user isn’t charged more.
+
+### Modified Protobuf Messages
+
+#### ConsensusCustomFee
+
+The `ConsensusCustomFee` message defines the type of fee and the account receiving the fee assessed during a message submission to the associated topic. A custom fee may only be a `FixedFee` and must specify a fee collector account to receive the assessed fees.
+
+```protobuf
+message ConsensusCustomFee {
+  // Fixed fee to be charged
+  FixedFee fixed_fee = 1;
+
+  // The account to receive the custom fee
+  AccountID fee_collector_account_id = 2;
+}
+```
+
+#### ConsensusCreateTopicTransactionBody
+
+The `ConsensusCreateTopicTransactionBody` message is updated to include an optional `custom_fees` property for specifying fixed fees during topic creation.
+
+```protobuf
+message ConsensusCreateTopicTransactionBody {
+  [...]
+  // The custom fees to be assessed during a message submission to this topic
+  repeated ConsensusCustomFee custom_fees = 2;
+}
+```
+
+#### ConsensusTopicInfo
+
+The `ConsensusTopicInfo` message is updated to include the current list of custom fixed fees associated with the topic.
+
+```protobuf
+message ConsensusTopicInfo {
+  [...]
+  // The custom fees to be assessed during a message submission to this topic
+  repeated ConsensusCustomFee custom_fees = 2;
+}
+```
+
+## Backwards Compatibility
+
+There are no known backwards compatibility issues. Existing topics without custom fees will continue to function as they currently do. New topics with custom fees will require appropriate updates to the Hedera SDKs, mirror nodes, and applications to support the new fee structures.
+
+## Security Implications
+
+The introduction of custom fees adds an additional layer of economic control but also introduces potential vectors for abuse, such as fee manipulation.
+
+## How to Teach This
+
+TBD
+
+## Reference Implementation
+
+Below is an example of creating a topic with a fixed fee.
+
+```JavaScript
+const { Client, TopicCreateTransaction, ConsensusCustomFee, AccountId, TokenId, PrivateKey } = require("@hashgraph/sdk");
+
+// Create the Hedera client
+const client = Client.forTestnet();
+
+// Define the submit key
+const submitKey = PrivateKey.generate();
+
+// Define the fee collector account ID
+const feeCollectorAccountId = AccountId.fromString("0.0.12345");
+
+// Define the fixed fee
+const customFee = new ConsensusCustomFee()
+    .setAmount(100)
+    .setDenominatingTokenId(TokenId.fromString("0.0.56789")); // Optional, HBAR if unset
+
+// Create the topic with the custom fee
+const transactionResponse = await new TopicCreateTransaction()
+    .setTopicMemo("Example Topic with Fixed Fee")
+    .setSubmitKey(submitKey)
+    .setCustomFee(customFee)
+    .execute(client);
+
+// Request the receipt of the transaction
+const receipt = await transactionResponse.getReceipt(client);
+
+console.log(`Created topic with ID: ${receipt.topicId}`);
+```
+
+This implementation shows the creation of a topic where each message submission requires a fixed fee of 100 tokens with ID 0.0.56789, collected by the specified account.
+
+## Rejected Ideas
+
+TBD
+
+## References
+
+TBD
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](../LICENSE) or (<https://www.apache.org/licenses/LICENSE-2.0>)

--- a/HIP/hip-991.md
+++ b/HIP/hip-991.md
@@ -10,7 +10,7 @@ status: Council Review
 last-call-date-time: 2024-07-24T07:00:00Z
 created: 2024-06-14
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/991
-updated: 2024-07-24
+updated: 2024-07-30
 ---
 
 ## Abstract

--- a/HIP/hip-991.md
+++ b/HIP/hip-991.md
@@ -28,10 +28,12 @@ This document outlines the development of a fixed fee system for the submission 
 
 **Feature Summary:**
 
-* Introduces an optional fee for submitting messages to a topic. When fixed fees are enabled, HBAR or FT payments are required for message submissions, with exemptions for holders of a submit key. Submit keys are not required for topics with fees.
-* Introduces a Fee Schedule Key for topic creation. This key can set the fee for message submissions, with exemptions for holders of a submit key.
-* Fees can be distributed similarly to fixed fees on the HTS, supporting multiple wallets, percentage distributions, and Fungible token in addition to HBAR.
-* Cannot add Key after creation - similar to tokens.
+* HCS topics can have an optional fee for submitting messages. Fees can be set in HBAR or HTS fungible tokens.
+* HCS topics have now a new Fee Schedule Key. This key can manage fee updates and send free messages to the topic. The key can be set at creation time and updated later (similarly to HTS tokens). If the HCS topic was created without a Fee Schedule Key, it cannot be added later.
+* Topic fees can be distributed similarly to fixed fees on the HTS, supporting multiple wallets, percentage distributions, and Fungible tokens in addition to HBAR.
+* Security measures to prevent unauthorized access to fee configurations and distributions.
+* Security measures to prevent users from being induced to pay unforeseen charges.
+* Distribution of collected fees akin to fixed fees on tokens, with support for distribution to multiple account IDs.
 
 **Benefits:**
 
@@ -67,71 +69,224 @@ We propose adding a fixed fee mechanism to the Hedera Consensus Service (HCS) fo
 
 ### Requirements and Scope
 
-* Implementation of an optional custom fee key on a topic ID during topic creation.
-* Requirement for users to allow HBAR or Tokens to be used to pay fees for message submissions, on an HCS topic bases.
-* Exemption from fees for users with a submit key (if a submit key is also present on the topic).
-* Distribution of collected fees akin to fixed fees on tokens, with support for distribution to multiple wallets, specified percentages.
-* Ensuring compatibility and integration with existing Hedera network protocols and services.
+* Topics can have a Fee Schedule Key set at creation time.
+* Fee Schedule Key can manage fee updates and send free messages to the topic.
+* The Fee Schedule Key can be updated with an update topic transaction signed by the Admin Key and the new Fee Schedule Key.
+* If the topic was created without a Fee Schedule Key, the key cannot be added later.
+* Topics can have fees for submitting messages.
+* Fees can be set at creation time.
+* Fees can be changed (updated or removed) from a topic with an update topic transaction signed by the Fee Schedule Key.
+* Fees are defined as a list of custom fee.
+* A custom fee can be set in HBAR or HTS fungible tokens, and must have an accountID as a receiver.
+* Fee payer must set an allowance in HBAR or HTS tokens to be used to pay fees for message submissions, on an HCS topic basis.
+* Allowance granted to topic ID does not allow the topic's Admin Key (or any of the topic's keys) to spend that allowance.
+* Fee payer must set can set a maximum fee per message, on an HCS topic basis.
+* Messages signed by the Fee Schedule Key or by a Submit Key don't incur fees.
+* Applications must set the `allowCustomFeesPayment` flag to true.
+* Default value of the `allowCustomFeesPayment` flag is false.
+* If the `allowCustomFeesPayment` flag is not set, or is not true, a transaction error will be fired.
 
 ### User Flows and Interaction
 
 * Users will specify the fee settings during the topic creation process through a simple interface in their Hedera client (refer to the creation of token custom fees/fixed fee for reference).
-* On submitting a message to a topic through a application or wallet interface, users will see the required fee and have the option to proceed or cancel.
+* Before submitting a message to a topic through an application or wallet interface, users must set an allowance and a maximum fee per message.
+* In case of user wallets, applications show the custom fees to the user before submitting the message.
 * Operators will get fee collections and distributions automatically through the custom fees just like they do in the token service currently.
 
-### Data Sharing, Privacy, and Security
+### New and Modified Protobuf Messages
 
-* Adherence to Hedera’s existing data privacy standards, ensuring that user identities and transaction details remain protected.
-* Implementation of security measures to prevent unauthorized access to fee configurations and distributions.
-* Callout on the HIP that when programmatically connecting to topics that have a custom fee key enabled, to set max fee on transactions so that if the fee is changed to be higher per message submission, the user isn’t charged more.
-
-### Modified Protobuf Messages
+The following is a list of suggested modifications to the protobuf messages structure to comply with the above requirements.
 
 #### ConsensusCustomFee
 
-The `ConsensusCustomFee` message defines the type of fee and the account receiving the fee assessed during a message submission to the associated topic. A custom fee may only be a `FixedFee` and must specify a fee collector account to receive the assessed fees.
+The `ConsensusCustomFee` message defines the type of fee and the account ID receiving the fee assessed during a message submission to the associated topic. A custom fee may only be a `FixedFee` and must specify a fee collector account to receive the assessed fees. `FixedFee` is an existing protobuf message and it must not be modified.
 
 ```protobuf
 message ConsensusCustomFee {
-  // Fixed fee to be charged
+  /**
+  * Fixed fee to be charged
+  */
   FixedFee fixed_fee = 1;
 
-  // The account to receive the custom fee
+  /**
+  * The account to receive the custom fee
+  */
   AccountID fee_collector_account_id = 2;
 }
 ```
 
 #### ConsensusCreateTopicTransactionBody
 
-The `ConsensusCreateTopicTransactionBody` message is updated to include an optional `custom_fees` property for specifying fixed fees during topic creation.
+The `ConsensusCreateTopicTransactionBody` message is updated to include the optional Fee Schedule Key and `custom_fees` property for specifying fixed fees during topic creation.
 
 ```protobuf
 message ConsensusCreateTopicTransactionBody {
   [...]
-  // The custom fees to be assessed during a message submission to this topic
-  repeated ConsensusCustomFee custom_fees = 2;
+
+  /**
+    * Access control for update/delete of custom fees. Null if there is no key.
+    */
+  Key fee_schedule_key = 8;
+
+  /**
+    * The custom fee to be assessed during a message submission to this topic
+    */
+  repeated ConsensusCustomFee custom_fees = 9;
+}
+```
+
+#### ConsensusUpdateTopicTransactionBody
+
+The `ConsensusUpdateTopicTransactionBody` message is updated to include the optional Fee Schedule Key and `custom_fees` property for specifying fixed fees during topic creation.
+
+```protobuf
+message ConsensusUpdateTopicTransactionBody {
+  [..]
+  /**
+    * Access control for update/delete of custom fees. Null if there is no key.
+    */
+  Key fee_schedule_key = 10;
+
+  /*
+   * The custom fee to be assessed during a message submission to this topic
+   */
+  repeated ConsensusCustomFee custom_fees = 11;
 }
 ```
 
 #### ConsensusTopicInfo
 
-The `ConsensusTopicInfo` message is updated to include the current list of custom fixed fees associated with the topic.
+The `ConsensusTopicInfo` message is updated to include the Fee Schedule Key and the current list of custom fixed fees associated with the topic.
 
 ```protobuf
 message ConsensusTopicInfo {
   [...]
-  // The custom fees to be assessed during a message submission to this topic
-  repeated ConsensusCustomFee custom_fees = 2;
+  /**
+    * Access control for update/delete of custom fees. Null if there is no key.
+    */
+  Key fee_schedule_key = 10;
+
+  /*
+   * The custom fee to be assessed during a message submission to this topic
+   */
+  repeated ConsensusCustomFee custom_fees = 11;
 }
 ```
 
+#### ConsensusSubmitMessageTransactionBody
+
+The `ConsensusSubmitMessageTransactionBody` message is updated to include the `allowCustomFeesPayment` flag.
+
+```protobuf
+message ConsensusSubmitMessageTransactionBody {
+  [...]
+
+  /**
+    * Flag to allow custom fee payment for this transaction. Default is false.
+    */
+  bool allow_custom_fees_payment = 4;
+}
+```
+
+#### CryptoApproveAllowanceTransactionBody
+
+The `CryptoApproveAllowanceTransactionBody` message is updated to include one or more `ConsensusCryptoFeeScheduleAllowance` and one or more `ConsensusTokenFeeScheduleAllowance` messages.
+
+```protobuf
+message CryptoApproveAllowanceTransactionBody {
+  [...]
+  /**
+   * List of hbar allowances approved by the account owner.
+   */
+  repeated ConsensusCryptoFeeScheduleAllowance consensus_crypto_fee_schedule_allowances = 4;
+
+  /**
+   * List of fungible token allowances approved by the account owner.
+   */
+  repeated ConsensusTokenFeeScheduleAllowance consensus_token_fee_schedule_allowances = 5;
+}
+```
+
+#### ConsensusCryptoFeeScheduleAllowance
+
+This is a new protobuf message definition to enable crypto allowance for topics.
+
+```protobuf
+/**
+ * An approved allowance of hbar transfers for a spender.
+ */
+message ConsensusCryptoFeeScheduleAllowance {
+  /**
+   * The account ID of the hbar owner (ie. the grantor of the allowance).
+   */
+  AccountID owner = 1;
+
+  /**
+   * The topic ID enabled to spend fees from the hbar allowance.
+   */
+  TopicID spender = 2;
+
+  /**
+   * The amount of the spender's allowance in tinybars.
+   */
+  int64 amount = 3;
+
+  /**
+   * The maximum amount of the spender's token allowance per message.
+   */
+  int64 amount_per_message = 4;
+}
+```
+
+#### ConsensusTokenFeeScheduleAllowance
+
+This is a new protobuf message definition to enable token allowance for topics.
+
+```protobuf
+/**
+ * An approved allowance of fungible token transfers for a spender.
+ */
+message ConsensusTokenFeeScheduleAllowance {
+  /**
+   * The token that the allowance pertains to.
+   */
+  TokenID tokenId = 1;
+
+  /**
+   * The account ID of the token owner (ie. the grantor of the allowance).
+   */
+  AccountID owner = 2;
+
+  /**
+   * The topic ID enabled to spend fees from the token allowance.
+   */
+  TopicID spender = 3;
+
+  /**
+   * The maximum amount of the spender's token allowance.
+   */
+  int64 amount = 4;
+
+  /**
+   * The maximum amount of the spender's token allowance per message.
+   */
+  int64 amount_per_message = 5;
+}
+```
+
+### SDKs and Mirror Node services
+
+This document does not contain the details about the implementation updates required by the SDKs and the Mirror Node to comply with the HIP-991 specifications. A suggested example for the JavaScript SDK is described in the [Reference Implementation](#reference-implementation) section.
+
 ## Backwards Compatibility
 
-There are no known backwards compatibility issues. Existing topics without custom fees will continue to function as they currently do. New topics with custom fees will require appropriate updates to the Hedera SDKs, mirror nodes, and applications to support the new fee structures.
+The HIP introduces new features while ensuring compatibility and integration with existing Hedera network protocols and services.
+New topics with custom fees will require appropriate updates to the Hedera SDKs, mirror nodes, and applications to support the new fee structures.
+There are no known backward compatibility issues. Existing topics without custom fees will continue to function as they currently do.
 
 ## Security Implications
 
-The introduction of custom fees adds an additional layer of economic control but also introduces potential vectors for abuse, such as fee manipulation.
+The introduction of custom fees adds an additional layer of economic control but also introduces potential vectors for abuse, such as fee manipulation. To address these issues, this HIP complies with the current security requirements regarding allowance for moving user's funds. In particular, before being able to send paid HCS messages to a topic, the users should previously set an allowance for the recipient topic, the same way they do in the case of HTS, to allow paying for fixed or custom fees. The user can also set a maximum fee per message. The default value for both parameters is 0.
 
 ## How to Teach This
 
@@ -139,11 +294,9 @@ TBD
 
 ## Reference Implementation
 
-Below is an example of creating a topic with a fixed fee.
+Below is a pseudo-code example of creating a topic with a fixed fee, setting the allowance, and sending a message.
 
 ```JavaScript
-const { Client, TopicCreateTransaction, ConsensusCustomFee, AccountId, TokenId, PrivateKey } = require("@hashgraph/sdk");
-
 // Create the Hedera client
 const client = Client.forTestnet();
 
@@ -154,32 +307,46 @@ const submitKey = PrivateKey.generate();
 const feeCollectorAccountId = AccountId.fromString("0.0.12345");
 
 // Define the fixed fee
-const customFee = new ConsensusCustomFee()
-    .setAmount(100)
-    .setDenominatingTokenId(TokenId.fromString("0.0.56789")); // Optional, HBAR if unset
+const topicCustomFee = new TopicCustomFee()
+  .setAmount(100) // 100 tokens are transferred to the fee collecting account each time this token is transferred
+  .setDenominatingTokenId(TokenId.fromString("0.0.56789")) // // The token to charge the fee in. HBAR if unset
+  .setFeeCollectorAccountId(feeCollectorAccountId); // 100 tokens are sent to this account for each HCS message to the topic
 
 // Create the topic with the custom fee
 const transactionResponse = await new TopicCreateTransaction()
-    .setTopicMemo("Example Topic with Fixed Fee")
-    .setSubmitKey(submitKey)
-    .setCustomFee(customFee)
-    .execute(client);
+  .setTopicMemo("Example Topic with Fixed Fee")
+  .setTopicCustomFees([topicCustomFee]) // List of custom fees. In this example, a single fixed fee in tokens
+  .execute(client);
 
 // Request the receipt of the transaction
 const receipt = await transactionResponse.getReceipt(client);
-
 console.log(`Created topic with ID: ${receipt.topicId}`);
+
+[...]
+
+// Set allowance
+const spenderTopicId = new TopicID("0.0.54321")
+transactionResponse = new TopicAllowanceApproveTransaction()
+    .approveHbarAllowance(ownerAccount, spenderTopicId, Hbar.from(100), Hbar.from(2)); // Set owner, topicId, maximum allowance, and max per message
+    
+[...]
+
+// Send message to the topic
+transactionResponse = await new TopicMessageSubmitTransaction({ topicId: topicId, message: "Hello, HCS!" })
+  .setAllowCustomFeesPayment(true) // Make the agreement on payment explicit at the application level. Useful for any backend / non-front-user-facing application.
+  .execute(client);
+
 ```
 
 This implementation shows the creation of a topic where each message submission requires a fixed fee of 100 tokens with ID 0.0.56789, collected by the specified account.
 
 ## Rejected Ideas
 
-TBD
+N/A
 
 ## References
 
-TBD
+* [Authoritative source of Hedera protobufs](https://github.com/hashgraph/hedera-protobufs)
 
 ## Copyright/license
 

--- a/HIP/hip-991.md
+++ b/HIP/hip-991.md
@@ -10,7 +10,7 @@ status: Council Review
 last-call-date-time: 2024-07-24T07:00:00Z
 created: 2024-06-14
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/991
-updated: 2024-08-05
+updated: 2024-08-09
 ---
 
 ## Abstract
@@ -69,24 +69,60 @@ We propose adding a fixed fee mechanism to the Hedera Consensus Service (HCS) fo
 
 ### Requirements and Scope
 
-* Topics can have a Fee Schedule Key set at creation time.
-* Fee Schedule Key can manage fee updates and send free messages to the topic.
-* Fee Schedule Key follows the same "Lower privilege key" rules introduced by [HIP-540](https://hips.hedera.com/hip/hip-540), that means:
-  * Only the admin key should be able to remove the Fee Schedule Key.
-  * Fee Schedule Key can change itself to another valid or unusable key.
-* If the topic was created without a Fee Schedule Key, the key cannot be added later.
-* Topics can have fees for submitting messages.
-* Fees can be set at creation time.
-* Fees can be changed (updated or removed) from a topic with an update topic transaction signed by the Fee Schedule Key.
+#### Main
+
+* Topics may have fees for submitting messages.
+
+#### Fees Definition
+
 * Fees are defined as a list of custom fee.
-* A custom fee can be set in HBAR or HTS fungible tokens, and must have an accountID as a receiver.
-* Fee payer must set an allowance in HBAR or HTS tokens to be used to pay fees for message submissions, on an HCS topic basis.
-* Allowance granted to topic ID does not allow the topic's Admin Key (or any of the topic's keys) to spend that allowance.
-* Fee payer must set can set a maximum fee per message, on an HCS topic basis.
-* Messages signed by the Fee Schedule Key or by a Submit Key don't incur fees.
-* Applications must set the `allowCustomFeesPayment` flag to true.
-* Default value of the `allowCustomFeesPayment` flag is false.
-* If the `allowCustomFeesPayment` flag is not set, or is not true, a transaction error will be fired.
+* The list of custom fees can contain a maximum of `MAX_CUSTOM_FEE_ENTRIES_FOR_TOPICS` entries.
+* A custom fee is defined leveraging the HTS's FixedFee data structure (see [ConsensusCustomFee](#consensuscustomfee)).
+* A custom fee can be set in HBAR or HTS fungible tokens and must have an accountID as the receiver.
+
+#### Fee Management
+
+* Fees can be set at creation time.
+* Fees can be changed (updated or removed) in a topic with an update topic transaction signed by the Fee Schedule Key.
+* Topics can have a Fee Schedule Key set at creation time.
+* The Fee Schedule Key can manage fee updates and send free messages to the topic.
+* The Fee Schedule Key follows the same "Lower privilege key" rules introduced by [HIP-540](https://hips.hedera.com/hip/hip-540), i.e:
+  * Only the Admin Key should be able to remove the Fee Schedule Key.
+  * The Fee Schedule Key can change itself to another valid or unusable key.
+* If the topic was created without a Fee Schedule Key, the key cannot be added later.
+
+#### Fee Payment Pre-Requisites
+
+* The fee payer must set an allowance (total fees and maximum fee per message) in HBAR or HTS tokens to be used to pay fees for message submissions on an HCS topic basis.
+* Allowance granted to a Topic ID does not allow the Topic's Admin Key (or any of the Topic's keys) to spend that allowance outside of fee payments.
+  
+#### Fee Payment Pre-Requisites (SDK)
+
+* When using the official SDK, the allowance transaction uses the `MAX_FEES` value for total fees and maximum fees per message by default. Developers must explicitly set these values if they don't want the defaults to be applied.
+* When sending HCS messages via the SDKs, applications must set the `allowCustomFeesPayment` flag to `true`.
+* The default value of the `allowCustomFeesPayment` flag is false.
+* If the `allowCustomFeesPayment` flag is not set or is not true, the SDK returns an error.
+* The `allowCustomFeesPayment` flag exists only in the SDK and isn't enforced by the network.
+
+#### Fee Exclusions
+
+* Topics can have a Free Messages Key List (FMKL)
+* FMKL can be set at creation time
+* FMKL can be updated with a TopicUpdateTransaction signed by the topic's Admin Key
+* FMKL has a maximum of `MAX_ENTRIES_FOR_FREE_MESSAGES_KEY_LIST` entries.
+* If a TopicMessageSubmitTransaction is submitted to the network and it contains a signature from a key included in the FMKL, no fees will be charged for that message.
+
+#### Fee Exclusions (SDK)
+
+* If developers don't provide an explicit list when creating the topic, the SDK will automatically include the following keys, if available, in the FMKL before submitting the transaction: Admin Key, Submit Key, and Fee Schedule Key.
+
+#### Suggested Parameters
+
+Actual values will be subject to discussion and verification during the development phase. Suggested values for the HIP parameters are as follows:
+
+* `MAX_CUSTOM_FEE_ENTRIES_FOR_TOPICS = 100`
+* `MAX_ENTRIES_FOR_FREE_MESSAGES_KEY_LIST = 1000`
+* `MAX_FEE = unsigned int 64`
 
 ### User Flows and Interaction
 
@@ -149,10 +185,15 @@ message ConsensusUpdateTopicTransactionBody {
     */
   Key fee_schedule_key = 10;
 
+  /**
+    * If the transaction contains a signer from this list, no custom fees are applied.
+    */
+  repeated Key free_messages_key_list = 11;
+
   /*
    * The custom fee to be assessed during a message submission to this topic
    */
-  repeated ConsensusCustomFee custom_fees = 11;
+  repeated ConsensusCustomFee custom_fees = 12;
 }
 ```
 
@@ -168,25 +209,15 @@ message ConsensusTopicInfo {
     */
   Key fee_schedule_key = 10;
 
+  /**
+    * If the transaction contains a signer from this list, no custom fees are applied.
+    */
+  repeated Key free_messages_key_list = 11;
+
   /*
    * The custom fee to be assessed during a message submission to this topic
    */
   repeated ConsensusCustomFee custom_fees = 11;
-}
-```
-
-#### ConsensusSubmitMessageTransactionBody
-
-The `ConsensusSubmitMessageTransactionBody` message is updated to include the `allowCustomFeesPayment` flag.
-
-```protobuf
-message ConsensusSubmitMessageTransactionBody {
-  [...]
-
-  /**
-    * Flag to allow custom fee payment for this transaction. Default is false.
-    */
-  bool allow_custom_fees_payment = 4;
 }
 ```
 
@@ -276,9 +307,9 @@ message ConsensusTokenFeeScheduleAllowance {
 }
 ```
 
-### SDKs and Mirror Node services
+### SDKs and Mirror Node Services
 
-This document does not contain the details about the implementation updates required by the SDKs and the Mirror Node to comply with the HIP-991 specifications. A suggested example for the JavaScript SDK is described in the [Reference Implementation](#reference-implementation) section.
+This document does not include the details of the implementation updates required by the SDKs and Mirror Node to comply with the HIP-991 specifications. A suggested example for the JavaScript SDK is described in the [Reference Implementation](#reference-implementation) section.
 
 ## Backwards Compatibility
 
@@ -288,7 +319,9 @@ There are no known backward compatibility issues. Existing topics without custom
 
 ## Security Implications
 
-The introduction of custom fees adds an additional layer of economic control but also introduces potential vectors for abuse, such as fee manipulation. To address these issues, this HIP complies with the current security requirements regarding allowance for moving user's funds. In particular, before being able to send paid HCS messages to a topic, the users should previously set an allowance for the recipient topic, the same way they do in the case of HTS, to allow paying for fixed or custom fees. The user can also set a maximum fee per message. The default value for both parameters is 0.
+The introduction of custom fees adds another layer of economic control, but also introduces potential vectors for abuse, such as fee manipulation. To address these issues, this HIP adheres to current security requirements regarding the authorization of moving user funds. In particular, before being able to send paid HCS messages to a topic, users should first set an allowance for the recipient topic, just as in the case of HTS, to allow payment of fixed or custom fees. The user can also set a maximum charge per message.
+
+At the network level, the default value for both allowance parameters is 0. At SDK level, the fees (total maximum amount and maximum fee per message) are always the maximum amount `MAX_FEE`. For this reason, the SDK documentation should contain a considerable callout on this point and be clear about the implications of not changing these default values.
 
 ## How to Teach This
 
@@ -296,7 +329,7 @@ TBD
 
 ## Reference Implementation
 
-Below is a pseudo-code example of creating a topic with a fixed fee, setting the allowance, and sending a message.
+The following is a pseudocode example for creating a topic with a fixed fee, setting the fee, and sending a message.
 
 ```JavaScript
 // Create the Hedera client
@@ -344,7 +377,8 @@ This implementation shows the creation of a topic where each message submission 
 
 ## Rejected Ideas
 
-N/A
+* Setting a mandatory network enforced `allowCustomFeesPayment` flag in HCS message transactions to allow payment of fees.
+* Setting 0 as default in SDKs for maximum fees.
 
 ## References
 


### PR DESCRIPTION
**Description**:

- Add: Users need to set allowance to pay for the fees in HBAR or Tokens
- Add: Fee Schedule Key specifications;
- Add: Allowance specifications;
- Add: Details about single features;
- Add: new and updated protobuf messages;
- Update: Updated CustomFixedFee (it already exists in the SDKs as a specification of the CustomFees) to ConsensusCustomFee
- Update: Paying with tokens is fully implemented with the current HIP
- Update: Users don't need to send HBAR while submitting the message
- Update: Restructured the HIP sections to comply with HIP-000;
- Update: While the gRPC service must be updated to support the new behaviours, the service interface changes accordingly to the new protobuf messages
- Fix: This HIP does not change the TransactionRecord message definition
- Fix: Names and references of som protobuf messages;
- Fix: Source code samples;
- Fix: Make linter happy;
- Fix: Fee Schedule Key can now send free messages, in addition to Submit Key;
- Fix: Reference implementation pseudo source code;

**Related issue(s)**:

Fixes # N/A

**Notes for reviewer**: 

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
