### PR TITLE
feat: create hip-1021

### DIFF
--- a/HIP/hip-1020.md
+++ b/HIP/hip-1020.md
@@ -1,0 +1,65 @@
+---
+hip: 1020
+title: Improve Assignment of Auto-Renew Account ID for Topics
+author: Michael Kantor (@kantorcodes)
+type: Standards Track
+category: Service
+status: Draft
+created: 2024-08-01
+requested-by: TierBot
+discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1020
+needs-council-approval: Yes
+---
+
+## Abstract
+
+This HIP proposes a modification to the Hedera Consensus Service (HCS) to:
+ - Enable setting the `autoRenewAccountId` to the account creating a `TopicCreateTransaction` when an Admin Key is not present during Topic Creation.
+ - It ensures that for all existing topics with only a Submit Key and no `autoRenewAccountId`, the original `payer_account_id` of the topic is retroactively set as the `autoRenewAccountId`.
+ - Automatically set the `autoRenewAccountId` to the `payer_account_id` of the Topic Id to prevent unintended user error.
+
+## Motivation
+
+Currently, when a Topic ID is created, the `autoRenewAccountId` is not automatically set to the account that initiated the transaction. Additionally:
+
+- It is only possible to set this field when an Admin Key is generated with the Topic. For topics that are created with the intention of being more "immutable," this is a risk.
+- Up until HIP-874 (https://github.com/hashgraph/hedera-improvement-proposal/pull/883/files), it was not easy to verify if a Topic was successfully created with an Autorenew Account Id, leading to more unexpected errors for users.
+
+This proposal seeks to simplify the process for users by making the auto-renewal mechanism seamless, eliminating the need for manual setting of the `autoRenewAccountId`. This change will reduce the potential for errors and ensure that topics are automatically renewed by the account responsible for their creation. Moreover, this proposal aims to provide backward compatibility by setting the `autoRenewAccountId` for previously created topics to the `payer_account_id` of those topics.
+
+## Rationale
+
+The proposed change simplifies user interactions with HCS and ensures consistency in managing topic renewals. Automatically associating the `autoRenewAccountId` with the topic `payer_account_id` account reduces complexity and the risk of unexpected topic expirations due to missing auto-renewal settings. For existing topics, retroactively setting the `autoRenewAccountId` to the `payer_account_id` ensures a uniform approach to topic management, especially when rent is enabled. At present, due to the inability to set an `autoRenewAccountId` on Topics without a Submit Key.
+
+## Specification
+
+### Automatic Setting of autoRenewAccountId
+
+When a new Topic ID is created, the `autoRenewAccountId` shall be automatically set to the account ID that creates the transaction, providing additional flexibility for when an Admin Key is not set.
+
+### Backwards Compatibility
+
+For all topics created before this proposal is implemented, the `autoRenewAccountId` shall be set to the original `payer_account_id` of the topic. This change shall be applied if and when rent is enabled for these topics.
+This retroactive setting shall not require any action from the original topic creators and shall be handled by the Hedera network.
+
+### Transaction Changes
+
+The current implementation allows for the `autoRenewAccountId` to be specified during topic creation only when an Admin Key is present. This proposal does not remove this capability but adds an automatic default to the transaction creator's account if not explicitly set, and the capability to set an `autoRenewAccountId` when only the Submit Key is present during creation.
+
+## Backwards Compatibility
+
+This proposal ensures backwards compatibility by defaulting the `autoRenewAccountId` to the original `payer_account_id` for all existing topics. This approach preserves the integrity of previously created topics and aligns future topic renewals with their original creators.
+
+## Implementation
+
+The Hedera node software will be updated to support automatic assignment of the `autoRenewAccountId` during the topic creation process.
+A migration process will be implemented to update the `autoRenewAccountId` for all existing topics to their the `payer_account_id`.
+
+## Drawbacks
+
+The primary drawback is the automatic nature of this feature, which may limit flexibility for users who wish to set a different `autoRenewAccountId`. However, this drawback is mitigated by allowing users to change the `autoRenewAccountId` post-creation if necessary.
+
+## Alternatives
+
+- **Future Rent Logic Adjustments:** If rent is enabled for TopicId Entities and a Topic Id was created before this HIP, rent would be charged to the `payer_account_id` of the Topic Id when an Autorenew Account Id was not present.
+- **No Retroactive Changes:** Implement the automatic setting of `autoRenewAccountId` only for new topics without making retroactive changes. This alternative would lead to inconsistent handling of auto-renewal across topics.

--- a/HIP/hip-1021.md
+++ b/HIP/hip-1021.md
@@ -4,11 +4,12 @@ title: Improve Assignment of Auto-Renew Account ID for Topics
 author: Michael Kantor (@kantorcodes)
 type: Standards Track
 category: Service
-status: Draft
+status: Review
 created: 2024-08-01
 requested-by: TierBot
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1021
 needs-council-approval: Yes
+updated: 2024-12-04
 ---
 
 ## Abstract

--- a/HIP/hip-1021.md
+++ b/HIP/hip-1021.md
@@ -4,7 +4,9 @@ title: Improve Assignment of Auto-Renew Account ID for Topics
 author: Michael Kantor (@kantorcodes)
 type: Standards Track
 category: Service
-status: Review
+needs-tsc-approval: Yes
+status: Last Call
+last-call-date-time: 2024-12-18T07:00:00Z
 created: 2024-08-01
 requested-by: TierBot
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1021

--- a/HIP/hip-1021.md
+++ b/HIP/hip-1021.md
@@ -1,5 +1,5 @@
 ---
-hip: 1020
+hip: 1021
 title: Improve Assignment of Auto-Renew Account ID for Topics
 author: Michael Kantor (@kantorcodes)
 type: Standards Track
@@ -7,7 +7,7 @@ category: Service
 status: Draft
 created: 2024-08-01
 requested-by: TierBot
-discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1020
+discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1021
 needs-council-approval: Yes
 ---
 


### PR DESCRIPTION
## Description

This pull request introduces HIP-1021, titled "Improve Assignment of Auto-Renew Account ID for Topics." The proposal aims to enhance the Hedera Consensus Service (HCS) by automating the assignment of the `autoRenewAccountId` to the account that creates a `TopicCreateTransaction`. This feature is particularly useful when an Admin Key is not present during topic creation, ensuring that the auto-renewal mechanism is consistently applied. 

The key changes include:
- **Automatic Assignment:** The `autoRenewAccountId` will automatically be set to the `payer_account_id` of the transaction if an Admin Key is not provided during topic creation.
- **Retroactive Application:** For existing topics that have only a Submit Key and no `autoRenewAccountId`, the original `payer_account_id` will be retroactively set as the `autoRenewAccountId`.
- **Consistency and Error Reduction:** This change aims to prevent user errors and ensure consistent management of topic renewals.

## Improvements

1. **Automatic Setting of Renewal Account:**
   - The account that creates a topic will now automatically be used for renewals. Users don't need to manually set this anymore, making the process simpler and reducing the chance of mistakes.

2. **Uniform Handling of Old Topics:**
   - For older topics without a set renewal account, the system will automatically use the original account that created them for rent. This makes renewals consistent across all topics.

3. **Fewer Mistakes:**
   - By automating the setup of the renewal account, there’s a lower risk of topics accidentally expiring due to missing settings.

4. **Easier for Users:**
   - Users no longer need to worry about setting up renewal accounts; the system handles it automatically, making the overall process more user-friendly.

5. **Ready for Future Changes:**
   - This change also prepares the system for potential future updates, like introducing rent for topics, ensuring everything is correctly configured in advance.