### PR TITLE
Update HIP-904 user stories

### DIFF
--- a/HIP/hip-904.md
+++ b/HIP/hip-904.md
@@ -11,7 +11,7 @@ status: Accepted
 last-call-date-time: 2024-04-08T07:00:00Z
 created: 2024-02-25
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/905
-updated: 2024-07-01
+updated: 2024-08-12
 replaces: 655, 777
 ---
 
@@ -316,7 +316,7 @@ mind and reject the token back to the GameNFT token treasury account.
 
 ## User stories
 
-### Crypto Transfer User Stories
+### Crypto Transfer User Stories (Existing Implementation)
 
 #### Sender
 

--- a/HIP/hip-904.md
+++ b/HIP/hip-904.md
@@ -340,8 +340,10 @@ mind and reject the token back to the GameNFT token treasury account.
    sender using CryptoTransfer to transfer tokens which I have not previously associated with.
 2. As a receiver with open auto association slots, I want to automatically receive tokens from a
    sender using CryptoTransfers to transfer tokens I have not previously associated with.
-3. As a user with receiver signature required enabled any airdrops sent to me will fail regardless
-   of open slots.
+3. As a user with receiver signature required enabled, if I have NOT signed the transaction, 
+   transfers sent to me will fail regardless of open slots.
+4. As a user with receiver signature required enabled, if I have signed the transaction, transfers 
+   sent to me will fail if I don't have open slots, otherwise I will receive it.
 
 ### Token Airdrop User Stories
 
@@ -381,8 +383,11 @@ mind and reject the token back to the GameNFT token treasury account.
    will be deleted.
 3. As a receiver who claims a token airdrop I will only be responsible for the transaction
    submission fee. No custom fees will be assessed to me as part of this transfer.
-4. As a user with receiver signature required enabled any airdrops sent to me will result in a
-   pending transfer, even with open slots.
+4. As a user with receiver signature required enabled, if I have NOT signed the transaction, 
+   airdrop sent to me will go to pending regardless of open slots. 
+5. As a user with receiver signature required enabled, if I have signed the transaction, 
+   airdrop sent to me will go to pending if I don't have open slots, otherwise I will receive 
+   the airdrop.
 
 ### General Airdrop User Stories
 1. As account owner for an account created by an EVM tool my experience with airdrops on Hedera is


### PR DESCRIPTION
Update HIP-904 user stories to clarify airdrops to a receiver with `receiverSigRequired=true`