### PR TITLE
Add note that memo field will be left blank

### DIFF
--- a/HIP/hip-583.md
+++ b/HIP/hip-583.md
@@ -11,7 +11,7 @@ last-call-date-time: 2022-10-17T07:00:00Z
 release: v0.37.0
 created: 2022-09-20
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/593
-updated: 2023-05-17
+updated: 2024-09-03
 requires: 32
 ---
 
@@ -276,6 +276,9 @@ and all other rules). If the account *does not* exist, then the account will be 
 specified in `HIP-32`, except that no key will be present on the newly created account. An account created in this
 manner will be known as a `Hollow Account` and will only be able to receive HBAR and applicable token transfers, but
 cannot take part in transactions submitted by others requiring its signature.
+
+* **UPDATE:** Initially, the `memo` of an auto-created account was set to “auto-created account," and the `memo` of a 
+  hollow account was set to "lazy-created account.” This has been changed and the field is left blank now.
 
 Since Hedera accounts require keys to ensure security, an `ECDSA` key matching the derived `evm address alias` must be
 provided in a future signed transaction issued by the owner of the account to take control of the account. Due to the


### PR DESCRIPTION
**Description**:

In the implementation, the memo field of an auto-created account was automatically set to "auto-created account," and the memo field of a hollow account was set to "lazy-created account." We thought this was rather confusing than helpful and, therefore, decided to leave the field blank.

This behavior was not specified in the original HIP and is thus added by this PR.