### PR TITLE
HIP 1052 - Add `file_hash` field to `/api/v1/blocks` endpoints' results 

### DIFF
--- a/HIP/hip-0000.md
+++ b/HIP/hip-0000.md
@@ -1,0 +1,93 @@
+---
+hip: <HIP number (assigned by the HIP editor), usually the PR number>
+title: Add the `file_hash` field to the `/api/v1/blocks` endpoints' results
+author: Giuseppe Bertone <giuseppe.bertone@hashgraph.com>
+working-group: Giuseppe Bertone <giuseppe.bertone@hashgraph.com>
+requested-by: Giuseppe Bertone <giuseppe.bertone@hashgraph.com>
+type: Standards Track
+category: Mirror
+needs-council-approval: Yes
+status: Draft
+created: 2024-09-23
+discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1052
+updated: 2024-09-23
+requires: N/A
+replaces: N/A
+superseded-by: N/A
+---
+
+## Abstract
+
+This HIP proposes to expose the SHA384 hash of the decompressed record file already present in the Mirror Node's DB using the REST APIs via the `/api/v1/blocks` endpoints.
+
+## Motivation
+
+To make it easier to download, store, and share record files, it's important to be able to follow a trusted mirror node.
+The ability to easily verify that the downloaded record files match the canonical chain exposed by a trusted mirror node is a step in this direction.
+
+## Rationale
+
+The current Mirror Node REST API `/api/v1/blocks` endpoints provide information about the Hedera record file (or virtual blocks).
+
+The data returned includes the record file name, but not its hash. The only hashes present in the result are the `hash` and `previous_hash` fields, which represent the hash of a portion of the contents of the record file.
+
+The SHA384 hash of the decompressed record file is already computed and stored in the Mirror Node's DB (`file_hash` column) during the record file import operations, so exposing this value via the REST APIs does not affect service performance.
+
+## User stories
+
+- As a mirror node operator, I want to verify that a record file I own or have downloaded is included and verified in the canonical chain by another mirror node.
+  
+## Specification
+
+The `/api/v1/blocks` and `/api/v1/blocks/{hashOrNumber}` endpoints should return an additional `file_hash` field containing the SHA384 hash of the decompressed record file.
+
+## Backwards Compatibility
+
+The `file_hash` field is added to the response payload of the `/api/v1/blocks` endpoints. This HIP does not modify any existing field, so the modification should be fully backward compatible with any existing application.
+
+## Security Implications
+
+This HIP does not introduce any security concerns to the current Mirror Node's REST API service.
+
+## How to Teach This
+
+The HIP is pretty straightforward: just update the documentation to make people aware of the additional field.
+
+## Reference Implementation
+
+This is an example of the expected payload of `/api/v1/blocks` endpoints after applying this HIP:
+
+```json
+{
+  "count": 4682,
+  "file_hash": "0xda59bf5e44ce940ec3925b8a0fabd7efd295115f01433da5340d6aed3815e0ce3c2cf0e08f7008e1b7d5e8798e3efd41",
+  "hapi_version": "0.53.0",
+  "hash": "0x5dc9c330ce6caaace43c09bec681b796785128998e33b08f2de251e86f70b6219f17813ddb8450dd24f91cdaed9d587b",
+  "name": "2024-09-23T12_30_48.002037911Z.rcd.gz",
+  "number": 69525892,
+  "previous_hash": "0xe2c73bb8009393a7d3c35564340a5baa863c0d2a51c5f792480dce63032adb4bd0eaf6a1f2c0723fc51964972eb83867",
+  "size": 1141037,
+  "timestamp": {
+    "from": "1727094648.002037911",
+    "to": "1727094649.987719741"
+  },
+  "gas_used": 0,
+  "logs_bloom": "0x"
+}
+```
+
+## Rejected Ideas
+
+N/A
+
+## Open Issues
+
+N/A
+
+## References
+
+- [Current Mirror Node's REST API documentation](https://mainnet.mirrornode.hedera.com/api/v1/docs/)
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](../LICENSE) or (<https://www.apache.org/licenses/LICENSE-2.0>)

--- a/HIP/hip-1052.md
+++ b/HIP/hip-1052.md
@@ -1,6 +1,6 @@
 ---
-hip: <HIP number (assigned by the HIP editor), usually the PR number>
-title: Add the `file_hash` field to the `/api/v1/blocks` endpoints' results
+hip: 1052
+title: Add `file_hash` field to `/api/v1/blocks` endpoints' results
 author: Giuseppe Bertone <giuseppe.bertone@hashgraph.com>
 working-group: Giuseppe Bertone <giuseppe.bertone@hashgraph.com>
 requested-by: Giuseppe Bertone <giuseppe.bertone@hashgraph.com>
@@ -10,10 +10,7 @@ needs-council-approval: Yes
 status: Draft
 created: 2024-09-23
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1052
-updated: 2024-09-23
-requires: N/A
-replaces: N/A
-superseded-by: N/A
+updated: 2024-10-02
 ---
 
 ## Abstract


### PR DESCRIPTION
**Description**:

This HIP proposes to expose the SHA384 hash of the decompressed record file already present in the Mirror Node's DB using the REST APIs via the `/api/v1/blocks` endpoints.

**Related issue(s)**:

N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
