### PR TITLE
HIP-980: Add shadow fork support as a rejected idea

### DIFF
--- a/HIP/hip-980.md
+++ b/HIP/hip-980.md
@@ -6,7 +6,7 @@ working-group: Steven Sheehy <@steven-sheehy>, Nana Essilfie-Conduah <nana@swirl
 type: Standards Track
 category: Mirror
 needs-council-approval: Yes
-status: Accepted
+status: In review
 created: 2024-06-03
 requested-by: Solo Labs
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/981
@@ -15,11 +15,11 @@ updated: 2024-06-25
 
 ## Abstract
 
-This HIP enhances part of the mirror node REST APIs to support querying by timestamp. This will allow users to query for tokens, transactions, and accounts that were created at a specific timestamp.
+This HIP enhances part of the mirror node REST APIs to support querying by timestamp. This will allow users to query for the historical state of an entity on the network.
 
 ## Motivation
 
-To enhance user experience and allow users or developers to query data from a specific point in time we will add a timestamp query parameter to some of the REST APIs, which are missing this support.
+To enhance user experience and allow users or developers to the state of an entity a specific point in time we will add a timestamp query parameter to all of the entity-based REST APIs that currently don't have one.
 This change will be especially valuable for building the foundation of the so-called shadow fork functionality, where a user or developer can use a local mirror node instance but run it against a production environment state.
 Having this support, users or developers will have the ability to use public state data to simulate and troubleshoot existing issues or replay historical transactions using local mirror node instance against production state.
 
@@ -30,9 +30,9 @@ for the simulations.
 
 ## User stories
 
-- As a user of mirror node, I want to be able to query historical data for accounts, contracts, tokens, and transactions that were created at a specific timestamp.
+- As a user of mirror node, I want to be able to query for the historical state of accounts, tokens, and other network entities.
 - As a user of mirror node, I want to be able to run locally an `eth_call`, `eth_estimateGas` or `eth_debugTraceTransaction` call that fails on a production environment against the corresponding public state.
-- As a developer of mirror node, I want to be able to test new feature locally against a real life data from a public environment, so that I have better understanding of the feature behavior.
+- As a mirror node developer, I want to be able to test new features locally against production state, so that I have better understanding of the feature behavior.
 
 ## Specification
 
@@ -47,14 +47,19 @@ The proposed enhancement involves adding a query parameter `timestamp` to the ex
 
 **Timestamp Query Parameter**
 
-A new `timestamp` query parameter will be added to search for different resources. This query parameter will represent a consensus timestamp in a Unix format in `seconds.nanoseconds` format and will have an optional comparison operator. That is, it will search for results that `equal`, `not equal`, are `greater` or `less` than the timestamp itself or its seconds component.
+A new `timestamp` query parameter will be added to search for different resources. This query parameter will represent a consensus timestamp in a Unix format in `seconds.nanoseconds` format and will have an optional comparison operator. That is, it will search for results that `equal`, `greater` or `less` than the timestamp itself or its seconds component.
 
-`/api/v1/accounts/{idOrAliasOrEvmAddress}/tokens?timestamp={value}`
-`/api/v1/accounts/{idOrAliasOrEvmAddress}/nfts?timestamp={value}`
-`/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/crypto?timestamp={value}`
-`/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/nfts?timestamp={value}`
-`/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/tokens?timestamp={value}`
-`/api/v1/tokens/{tokenId}/nfts/{serialNumber}?timestamp={value}`
+The exact names of the operators will be `eq`, `gt` and `lt`. The user shouldn't know the exact timestamp value of the time when an entity was created or updated, so that the parameter to work correctly. The API will return the results that match the timestamp or the closest one to it.
+For example, if we have an `asc` ordering of the results, then `?timestamp=X`, `timestamp=eq:X`, or `timestamp=lte:X` will have the same behaviour and vice versa, where `X` is the desired timestamp.
+
+```
+/api/v1/accounts/{idOrAliasOrEvmAddress}/tokens?timestamp={value}
+/api/v1/accounts/{idOrAliasOrEvmAddress}/nfts?timestamp={value}
+/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/crypto?timestamp={value}
+/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/nfts?timestamp={value}
+/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/tokens?timestamp={value}
+/api/v1/tokens/{tokenId}/nfts/{serialNumber}?timestamp={value}
+```
 
 **Request**
 ```
@@ -63,9 +68,13 @@ A new `timestamp` query parameter will be added to search for different resource
 **Example Request**
 
 ```
-GET api/v1/accounts/4408244/tokens?order=desc?timestamp=1705334449.803393003
+GET api/v1/accounts/4408244/tokens?order=asc&timestamp=lte:1725334849.603493001
 ```
-Note: if ```limit``` is not specified in the request, response will be limited to 25 by default
+Note that the following two requests will return the same response as the query above:
+```
+GET api/v1/accounts/4408244/tokens?order=asc&timestamp=1705334449.803393003
+GET api/v1/accounts/4408244/tokens?order=asc&timestamp=eq:1705334449.803393003
+```
 
 **Response**
 
@@ -92,6 +101,8 @@ Note: if ```limit``` is not specified in the request, response will be limited t
 
 The change is backwards compatible as it is simply adding а query parameter to an existing route. The data required to filter by timestamp is already stored in the mirror node.
 
+If a timestamp query parameter is not provided, the API will use the latest state of the entity as it does currently.
+
 ## Security Implications
 
 Historical timestamp filtering can slow down some of the queries, especially if the timestamp is not indexed or the data set is very large.
@@ -102,12 +113,7 @@ None
 
 ## References
 
-https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/tokens
-https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/nfts
-https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/allowances/crypto
-https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/allowances/nfts
-https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/allowances/tokens
-https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/tokens/tokenId/nfts/serialNumber
+https://mainnet-public.mirrornode.hedera.com/api/v1/docs/
 
 ## Copyright/license
 

--- a/HIP/hip-980.md
+++ b/HIP/hip-980.md
@@ -61,6 +61,8 @@ For example, if we have an `asc` ordering of the results, then `?timestamp=X`, `
 
 The `timestamp` query parameter will support having a range of timestamps. For example, `timestamp=gt:X&timestamp=lt:Y` will return a single result with the entity or entity related info in the most recent state within the range that is greater than `X` and less than `Y`, where `X` and `Y` are different timestamps.
 
+Here are the affected APIs with the query parameter added:
+
 ```
 /api/v1/accounts/{idOrAliasOrEvmAddress}/tokens?timestamp={value}
 /api/v1/accounts/{idOrAliasOrEvmAddress}/nfts?timestamp={value}
@@ -69,6 +71,9 @@ The `timestamp` query parameter will support having a range of timestamps. For e
 /api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/tokens?timestamp={value}
 /api/v1/tokens/{tokenId}/nfts/{serialNumber}?timestamp={value}
 ```
+
+Note: There is an existing API with a `timestamp` query parameter, which is `/api/v1/accounts/{idOrAliasOrEvmAddress}?timestamp={value}`. While parameter changes won't be applied for it, it's
+behaviour will reflect to actually return modification changes of all account fields. Currently, the timestamp filter is applied only to the transaction list. The balance info section will continue to have granularity of 15 minutes. 
 
 **Request**
 ```
@@ -87,6 +92,8 @@ GET api/v1/accounts/4408244/tokens?order=asc&timestamp=eq:1705334449.803393003
 
 **Response**
 
+The response format of all the mentioned APIs will be enhanced with additional timestamp range with `from` and `to` fields, reflecting the period in which the returned data state was valid. The `to` field will be null if the result represent the latest updated state.
+
 ```json
 {
   "tokens": [
@@ -97,7 +104,11 @@ GET api/v1/accounts/4408244/tokens?order=asc&timestamp=eq:1705334449.803393003
       "decimals": 0,
       "token_id": "0.0.4328145",
       "freeze_status": "NOT_APPLICABLE",
-      "kyc_status": "NOT_APPLICABLE"
+      "kyc_status": "NOT_APPLICABLE",
+      "timestamp": {
+        "from": "1705334449.803393003",
+        "to": null
+      }
     }
   ],
   "links": {

--- a/HIP/hip-980.md
+++ b/HIP/hip-980.md
@@ -51,10 +51,14 @@ The proposed enhancement involves adding a query parameter `timestamp` to the ex
 
 **Timestamp Query Parameter**
 
-A new `timestamp` query parameter will be added to search for different resources. This query parameter will represent a consensus timestamp in a Unix format in `seconds.nanoseconds` format and will have an optional comparison operator. That is, it will search for results that `equal`, `greater` or `less` than the timestamp itself or its seconds component.
+A new `timestamp` query parameter will be added to search for all entities and entity related information that are missing its support. It will be with the format of `array[string]`. 
+This query parameter will represent a single or multiple consensus timestamps in a Unix format in `seconds.nanoseconds` format and will have an optional comparison operator. 
+That is, it will search for results that are `equal`, `greater` or `less` than the timestamp itself or its seconds component.
 
 The exact names of the operators will be `eq`, `gt`, `gte`, `lt` and `lte`. The user doesn't need to know the exact timestamp at which an entity was created or updated for it to function. The API will return the results that match the timestamp or the closest one to it.
 For example, if we have an `asc` ordering of the results, then `?timestamp=X`, `timestamp=eq:X`, or `timestamp=lte:X` will have the same behaviour and vice versa, where `X` is the desired timestamp.
+
+The `timestamp` query parameter will support having a range of timestamps. For example, `timestamp=gt:X&timestamp=lt:Y` will return a single result with the entity or entity related info in the most recent state within the range that is greater than `X` and less than `Y`, where `X` and `Y` are different timestamps.
 
 ```
 /api/v1/accounts/{idOrAliasOrEvmAddress}/tokens?timestamp={value}

--- a/HIP/hip-980.md
+++ b/HIP/hip-980.md
@@ -11,22 +11,24 @@ last-call-date-time: 2024-07-23T07:00:00Z
 created: 2024-06-03
 requested-by: Solo Labs
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/981
-updated: 2024-08-16
+updated: 2024-10-09
 ---
 
 ## Abstract
 
-This HIP enhances part of the mirror node REST APIs to support querying by timestamp. This will allow users to query for the historical state of any entity info on the network that currently misses this functionality.
+This HIP enhances part of the mirror node REST APIs to support querying by timestamp. This will allow users to query for
+the historical state of any entity info on the network that currently misses this functionality.
 
 ## Motivation
 
-To enhance user experience and allow users or developers to query the state of an entity at a specific point in time we will add a timestamp query parameter to all of the entity-based REST APIs that currently don't have one.
-This change will be especially valuable for building the foundation of the so-called shadow fork functionality, where a user or developer can use a local mirror node instance but run it against a production environment state.
-Having this support, users or developers will have the ability to use public state data to simulate and troubleshoot existing issues or replay historical transactions using local mirror node instance against production state.
+To enhance user experience and allow users or developers to query the state of an entity at a specific point in time we
+will add a timestamp query parameter to all of the entity-based REST APIs that currently don't have one.
 
 ## Rationale
 
-Users may want to run historical transactions on a local mirror node instance using public state data. To make this possible, some of the existing REST APIs should be enhanced with a timestamp query parameter, so that historical public data can be fetched and used
+Users may want to run historical transactions on a local mirror node instance using public state data. To make this
+possible, some of the existing REST APIs should be enhanced with a timestamp query parameter, so that historical public
+data can be fetched and used
 for the simulations.
 
 ## User stories
@@ -34,32 +36,42 @@ for the simulations.
 - As a user of mirror node, I want to be able to query for the historical state of nfts.
 - As a user of mirror node, I want to be able to query for the historical state of token relationships for an account.
 - As a user of mirror node, I want to be able to query for the historical state of allowances for an account.
-- As a user of mirror node, I want to be able to run locally an `eth_call` request that fails on a production environment against the corresponding public state.
-- As a user of mirror node, I want to be able to run locally an `eth_estimateGas` request that fails on a production environment against the corresponding public state.
-- As a user of mirror node, I want to be able to run locally an `eth_debugTraceTransaction` request that fails on a production environment against the corresponding public state.
-- As a mirror node developer, I want to be able to test new features locally against production state, so that I have better understanding of the feature behavior.
 
 ## Specification
 
 The proposed enhancement involves adding a query parameter `timestamp` to the existing routes:
 
-- `/api/v1/accounts/{idOrAliasOrEvmAddress}/tokens` to return correct historical information about an account and their associated fungible tokens for a specific timestamp
-- `/api/v1/accounts/{idOrAliasOrEvmAddress}/nfts` to return correct historical information about an account and their associated nfts for a specific timestamp
-- `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/crypto` to return correct historical information about an account's crypto allowances for a specific timestamp
-- `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/nfts` to return correct historical information about an account's NFT allowances for a specific timestamp
-- `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/tokens` to return correct historical information about an account's token allowances for a specific timestamp
-- `/api/v1/tokens/{tokenId}/nfts/{serialNumber}` to return correct historical information about an NFT for a specific timestamp
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/tokens` to return correct historical information about an account and their
+  associated fungible tokens for a specific timestamp
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/nfts` to return correct historical information about an account and their
+  associated nfts for a specific timestamp
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/crypto` to return correct historical information about an
+  account's crypto allowances for a specific timestamp
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/nfts` to return correct historical information about an account's
+  NFT allowances for a specific timestamp
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/tokens` to return correct historical information about an
+  account's token allowances for a specific timestamp
+- `/api/v1/tokens/{tokenId}/nfts/{serialNumber}` to return correct historical information about an NFT for a specific
+  timestamp
 
 **Timestamp Query Parameter**
 
-A new `timestamp` query parameter will be added to search for all entities and entity related information that are missing its support. It will be with the format of `array[string]`. 
-This query parameter will represent a single or multiple consensus timestamps in a Unix format in `seconds.nanoseconds` format and will have an optional comparison operator. 
-That is, it will search for results that are `equal`, `greater` or `less` than the timestamp itself or its seconds component.
+A new `timestamp` query parameter will be added to search for all entities and entity related information that are
+missing its support. It will be with the format of `array[string]`.
+This query parameter will represent a single or multiple consensus timestamps in a Unix format in `seconds.nanoseconds`
+format and will have an optional comparison operator.
+That is, it will search for results that are `equal`, `greater` or `less` than the timestamp itself or its seconds
+component.
 
-The exact names of the operators will be `eq`, `gt`, `gte`, `lt` and `lte`. The user doesn't need to know the exact timestamp at which an entity was created or updated for it to function. The API will return the results that match the timestamp or the closest one to it.
-For example, if we have an `asc` ordering of the results, then `?timestamp=X`, `timestamp=eq:X`, or `timestamp=lte:X` will have the same behaviour and vice versa, where `X` is the desired timestamp.
+The exact names of the operators will be `eq`, `gt`, `gte`, `lt` and `lte`. The user doesn't need to know the exact
+timestamp at which an entity was created or updated for it to function. The API will return the results that match the
+timestamp or the closest one to it.
+For example, if we have an `asc` ordering of the results, then `?timestamp=X`, `timestamp=eq:X`, or `timestamp=lte:X`
+will have the same behaviour and vice versa, where `X` is the desired timestamp.
 
-The `timestamp` query parameter will support having a range of timestamps. For example, `timestamp=gt:X&timestamp=lt:Y` will return a single result with the entity or entity related info in the most recent state within the range that is greater than `X` and less than `Y`, where `X` and `Y` are different timestamps.
+The `timestamp` query parameter will support having a range of timestamps. For example, `timestamp=gt:X&timestamp=lt:Y`
+will return a single result with the entity or entity related info in the most recent state within the range that is
+greater than `X` and less than `Y`, where `X` and `Y` are different timestamps.
 
 Here are the affected APIs with the query parameter added:
 
@@ -72,19 +84,25 @@ Here are the affected APIs with the query parameter added:
 /api/v1/tokens/{tokenId}/nfts/{serialNumber}?timestamp={value}
 ```
 
-Note: There is an existing API with a `timestamp` query parameter, which is `/api/v1/accounts/{idOrAliasOrEvmAddress}?timestamp={value}`. While parameter changes won't be applied for it, it's
-behaviour will reflect to actually return modification changes of all account fields. Currently, the timestamp filter is applied only to the transaction list. The balance info section will continue to have granularity of 15 minutes. 
+Note: There is an existing API with a `timestamp` query parameter, which is
+`/api/v1/accounts/{idOrAliasOrEvmAddress}?timestamp={value}`. While parameter changes won't be applied for it, it's
+behaviour will reflect to actually return modification changes of all account fields. Currently, the timestamp filter is
+applied only to the transaction list. The balance info section will continue to have granularity of 15 minutes.
 
 **Request**
+
 ```
 /api/v1/accounts/{idOrAliasOrEvmAddress}/tokens?timestamp={value}
 ```
+
 **Example Request**
 
 ```
 GET api/v1/accounts/4408244/tokens?order=asc&timestamp=lte:1725334849.603493001
 ```
+
 Note that the following two requests will return the same response as the query above:
+
 ```
 GET api/v1/accounts/4408244/tokens?order=asc&timestamp=1705334449.803393003
 GET api/v1/accounts/4408244/tokens?order=asc&timestamp=eq:1705334449.803393003
@@ -92,7 +110,9 @@ GET api/v1/accounts/4408244/tokens?order=asc&timestamp=eq:1705334449.803393003
 
 **Response**
 
-The response format of all the mentioned APIs will be enhanced with additional timestamp range with `from` and `to` fields, reflecting the period in which the returned data state was valid. The `to` field will be null if the result represent the latest updated state.
+The response format of all the mentioned APIs will be enhanced with additional timestamp range with `from` and `to`
+fields, reflecting the period in which the returned data state was valid. The `to` field will be null if the result
+represent the latest updated state.
 
 ```json
 {
@@ -119,17 +139,31 @@ The response format of all the mentioned APIs will be enhanced with additional t
 
 ## **Backwards Compatibility**
 
-The change is backwards compatible as it is simply adding a query parameter to an existing route. The data required to filter by timestamp is already stored in the mirror node.
+The change is backwards compatible as it is simply adding a query parameter to an existing route. The data required to
+filter by timestamp is already stored in the mirror node.
 
 If a timestamp query parameter is not provided, the API will use the latest state of the entity as it does currently.
 
 ## Security Implications
 
-Historical timestamp filtering can slow down some of the queries, especially if the timestamp is not indexed or the data set is very large.
+Historical timestamp filtering can slow down some of the queries, especially if the timestamp is not indexed or the data
+set is very large.
 
 ## Rejected Ideas
 
-None
+Initially, the HIP aimed to allow the grounding steps for supporting shadow fork on a local mirror node. This means
+users could run a local instance of the mirror node
+and use a public state of the network, including historical one. However, this idea was rejected, since the
+implementation of this feature would have meant having
+a lot of REST API requests against the public mirror nodes, which would have generated a heavy load on the network.
+Additionally, it would have been impractical
+for many users accustomed to rely on a public service, having this functionality (e.g. call eth_call or
+eth_debugTraceTransaction with a specific block number against a
+public service, which may be paid), to spend additional efforts of spinning their own local mirror node and sending
+their call against it.
+
+As a summary, this idea was rejected in favour of a public mirror node provider to allow this functionality as a
+service.
 
 ## References
 
@@ -137,4 +171,5 @@ https://mainnet-public.mirrornode.hedera.com/api/v1/docs/
 
 ## Copyright/license
 
-This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](https://www.notion.so/LICENSE) or (https://www.apache.org/licenses/LICENSE-2.0)
+This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](https://www.notion.so/LICENSE)
+or (https://www.apache.org/licenses/LICENSE-2.0)

--- a/HIP/hip-980.md
+++ b/HIP/hip-980.md
@@ -6,10 +6,11 @@ working-group: Steven Sheehy <@steven-sheehy>, Nana Essilfie-Conduah <nana@swirl
 type: Standards Track
 category: Mirror
 needs-council-approval: Yes
-status: Draft
+status: Accepted
 created: 2024-06-03
 requested-by: Solo Labs
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/981
+updated: 2024-06-25
 ---
 
 ## Abstract
@@ -37,7 +38,8 @@ for the simulations.
 
 The proposed enhancement involves adding a query parameter `timestamp` to the existing routes:
 
-- `/api/v1/accounts/{idOrAliasOrEvmAddress}/tokens` to return correct historical information about an account and their associated tokens for a specific timestamp
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/tokens` to return correct historical information about an account and their associated fungible tokens for a specific timestamp
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/nfts` to return correct historical information about an account and their associated nfts for a specific timestamp
 - `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/crypto` to return correct historical information about an account's crypto allowances for a specific timestamp
 - `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/nfts` to return correct historical information about an account's NFT allowances for a specific timestamp
 - `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/tokens` to return correct historical information about an account's token allowances for a specific timestamp
@@ -48,6 +50,7 @@ The proposed enhancement involves adding a query parameter `timestamp` to the ex
 A new `timestamp` query parameter will be added to search for different resources. This query parameter will represent a consensus timestamp in a Unix format in `seconds.nanoseconds` format and will have an optional comparison operator. That is, it will search for results that `equal`, `not equal`, are `greater` or `less` than the timestamp itself or its seconds component.
 
 `/api/v1/accounts/{idOrAliasOrEvmAddress}/tokens?timestamp={value}`
+`/api/v1/accounts/{idOrAliasOrEvmAddress}/nfts?timestamp={value}`
 `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/crypto?timestamp={value}`
 `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/nfts?timestamp={value}`
 `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/tokens?timestamp={value}`
@@ -100,6 +103,7 @@ None
 ## References
 
 https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/tokens
+https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/nfts
 https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/allowances/crypto
 https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/allowances/nfts
 https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/allowances/tokens

--- a/HIP/hip-980.md
+++ b/HIP/hip-980.md
@@ -1,6 +1,6 @@
 ---
 hip: 980
-title: Enhance mirror node rest APIs with timestamp query parameter
+title: Enhance mirror node entity rest APIs with timestamp query parameter
 author: Ivan Kavaldzhiev <ivan.kavaldzhiev@limechain.tech>
 working-group: Steven Sheehy <@steven-sheehy>, Nana Essilfie-Conduah <nana@swirldslabs.com>
 type: Standards Track
@@ -15,11 +15,11 @@ updated: 2024-06-25
 
 ## Abstract
 
-This HIP enhances part of the mirror node REST APIs to support querying by timestamp. This will allow users to query for the historical state of an entity on the network.
+This HIP enhances part of the mirror node REST APIs to support querying by timestamp. This will allow users to query for the historical state of any entity info on the network that currently misses this functionality.
 
 ## Motivation
 
-To enhance user experience and allow users or developers to query the state of an entity a specific point in time we will add a timestamp query parameter to all of the entity-based REST APIs that currently don't have one.
+To enhance user experience and allow users or developers to query the state of an entity at a specific point in time we will add a timestamp query parameter to all of the entity-based REST APIs that currently don't have one.
 This change will be especially valuable for building the foundation of the so-called shadow fork functionality, where a user or developer can use a local mirror node instance but run it against a production environment state.
 Having this support, users or developers will have the ability to use public state data to simulate and troubleshoot existing issues or replay historical transactions using local mirror node instance against production state.
 
@@ -30,8 +30,12 @@ for the simulations.
 
 ## User stories
 
-- As a user of mirror node, I want to be able to query for the historical state of accounts, tokens, and other network entities.
-- As a user of mirror node, I want to be able to run locally an `eth_call`, `eth_estimateGas` or `eth_debugTraceTransaction` call that fails on a production environment against the corresponding public state.
+- As a user of mirror node, I want to be able to query for the historical state of nfts.
+- As a user of mirror node, I want to be able to query for the historical state of token relationships for an account.
+- As a user of mirror node, I want to be able to query for the historical state of allowances for an account.
+- As a user of mirror node, I want to be able to run locally an `eth_call` request that fails on a production environment against the corresponding public state.
+- As a user of mirror node, I want to be able to run locally an `eth_estimateGas` request that fails on a production environment against the corresponding public state.
+- As a user of mirror node, I want to be able to run locally an `eth_debugTraceTransaction` request that fails on a production environment against the corresponding public state.
 - As a mirror node developer, I want to be able to test new features locally against production state, so that I have better understanding of the feature behavior.
 
 ## Specification

--- a/HIP/hip-980.md
+++ b/HIP/hip-980.md
@@ -103,7 +103,7 @@ GET api/v1/accounts/4408244/tokens?order=asc&timestamp=eq:1705334449.803393003
 
 ## **Backwards Compatibility**
 
-The change is backwards compatible as it is simply adding а query parameter to an existing route. The data required to filter by timestamp is already stored in the mirror node.
+The change is backwards compatible as it is simply adding a query parameter to an existing route. The data required to filter by timestamp is already stored in the mirror node.
 
 If a timestamp query parameter is not provided, the API will use the latest state of the entity as it does currently.
 

--- a/HIP/hip-980.md
+++ b/HIP/hip-980.md
@@ -19,7 +19,7 @@ This HIP enhances part of the mirror node REST APIs to support querying by times
 
 ## Motivation
 
-To enhance user experience and allow users or developers to the state of an entity a specific point in time we will add a timestamp query parameter to all of the entity-based REST APIs that currently don't have one.
+To enhance user experience and allow users or developers to query the state of an entity a specific point in time we will add a timestamp query parameter to all of the entity-based REST APIs that currently don't have one.
 This change will be especially valuable for building the foundation of the so-called shadow fork functionality, where a user or developer can use a local mirror node instance but run it against a production environment state.
 Having this support, users or developers will have the ability to use public state data to simulate and troubleshoot existing issues or replay historical transactions using local mirror node instance against production state.
 
@@ -49,7 +49,7 @@ The proposed enhancement involves adding a query parameter `timestamp` to the ex
 
 A new `timestamp` query parameter will be added to search for different resources. This query parameter will represent a consensus timestamp in a Unix format in `seconds.nanoseconds` format and will have an optional comparison operator. That is, it will search for results that `equal`, `greater` or `less` than the timestamp itself or its seconds component.
 
-The exact names of the operators will be `eq`, `gt` and `lt`. The user shouldn't know the exact timestamp value of the time when an entity was created or updated, so that the parameter to work correctly. The API will return the results that match the timestamp or the closest one to it.
+The exact names of the operators will be `eq`, `gt`, `gte`, `lt` and `lte`. The user doesn't need to know the exact timestamp at which an entity was created or updated for it to function. The API will return the results that match the timestamp or the closest one to it.
 For example, if we have an `asc` ordering of the results, then `?timestamp=X`, `timestamp=eq:X`, or `timestamp=lte:X` will have the same behaviour and vice versa, where `X` is the desired timestamp.
 
 ```

--- a/HIP/hip-xxx.md
+++ b/HIP/hip-xxx.md
@@ -8,7 +8,7 @@ category: Mirror
 needs-council-approval: Yes
 status: Draft
 created: 2024-06-03
-requested-by: 
+requested-by: Solo Labs
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/981
 ---
 

--- a/HIP/hip-xxx.md
+++ b/HIP/hip-xxx.md
@@ -1,0 +1,110 @@
+---
+hip: xxx
+title: Enhance mirror node rest APIs with timestamp query parameter
+author: Ivan Kavaldzhiev <ivan.kavaldzhiev@limechain.tech>
+working-group: Steven Sheehy <@steven-sheehy>, Nana Essilfie-Conduah <nana@swirldslabs.com>
+type: Standards Track
+category: Mirror
+needs-council-approval: Yes
+status: Draft
+created: 2024-06-03
+requested-by: 
+discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/xxx
+---
+
+## Abstract
+
+This HIP enhances part of the mirror node REST APIs to support querying by timestamp. This will allow users to query for tokens, transactions, and accounts that were created at a specific timestamp.
+
+## Motivation
+
+To enhance user experience and allow users or developers to query data from a specific point in time we will add a timestamp query parameter to some of the REST APIs, which are missing this support.
+This change will be especially valuable for building the foundation of the so-called shadow fork functionality, where a user or developer can use a local mirror node instance but run it against a production environment state.
+Having this support, users or developers will have the ability to use public state data to simulate and troubleshoot existing issues or replay historical transactions using local mirror node instance against production state.
+
+## Rationale
+
+Users may want to run historical transactions on a local mirror node instance using public state data. To make this possible, some of the existing REST APIs should be enhanced with a timestamp query parameter, so that historical public data can be fetched and used
+for the simulations.
+
+## User stories
+
+- As a user of mirror node, I want to be able to query historical data for accounts, contracts, tokens, and transactions that were created at a specific timestamp.
+- As a user of mirror node, I want to be able to run locally an `eth_call`, `eth_estimateGas` or `eth_debugTraceTransaction` call that fails on a production environment against the corresponding public state.
+- As a developer of mirror node, I want to be able to test new feature locally against a real life data from a public environment, so that I have better understanding of the feature behavior.
+
+## Specification
+
+The proposed enhancement involves adding a query parameter `timestamp` to the existing routes:
+
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/tokens` to return correct historical information about an account and their associated tokens for a specific timestamp
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/crypto` to return correct historical information about an account's crypto allowances for a specific timestamp
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/nfts` to return correct historical information about an account's NFT allowances for a specific timestamp
+- `/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/tokens` to return correct historical information about an account's token allowances for a specific timestamp
+- `/api/v1/tokens/{tokenId}/nfts/{serialNumber}` to return correct historical information about an NFT for a specific timestamp
+
+**Timestamp Query Parameter**
+
+A new `timestamp` query parameter will be added to search for different resources. This query parameter will represent a consensus timestamp in a Unix format in `seconds.nanoseconds` format and will have an optional comparison operator. That is, it will search for results that `equal`, `not equal`, are `greater` or `less` than the timestamp itself or its seconds component.
+
+`/api/v1/accounts/{idOrAliasOrEvmAddress}/tokens?timestamp={value}`
+`/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/crypto?timestamp={value}`
+`/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/nfts?timestamp={value}`
+`/api/v1/accounts/{idOrAliasOrEvmAddress}/allowances/tokens?timestamp={value}`
+`/api/v1/tokens/{tokenId}/nfts/{serialNumber}?timestamp={value}`
+
+**Request**
+```
+/api/v1/accounts/{idOrAliasOrEvmAddress}/tokens?timestamp={value}
+```
+**Example Request**
+
+```
+GET api/v1/accounts/4408244/tokens?order=desc?timestamp=1705334449.803393003
+```
+Note: if ```limit``` is not specified in the request, response will be limited to 25 by default
+
+**Response**
+
+```json
+{
+  "tokens": [
+    {
+      "automatic_association": true,
+      "balance": 1,
+      "created_timestamp": "1705334449.803393003",
+      "decimals": 0,
+      "token_id": "0.0.4328145",
+      "freeze_status": "NOT_APPLICABLE",
+      "kyc_status": "NOT_APPLICABLE"
+    }
+  ],
+  "links": {
+    "next": null
+  }
+}
+```
+
+## **Backwards Compatibility**
+
+The change is backwards compatible as it is simply adding а query parameter to an existing route. The data required to filter by timestamp is already stored in the mirror node.
+
+## Security Implications
+
+Historical timestamp filtering can slow down some of the queries, especially if the timestamp is not indexed or the data set is very large.
+
+## Rejected Ideas
+
+None
+
+## References
+
+https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/tokens
+https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/allowances/crypto
+https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/allowances/nfts
+https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/accounts/idOrAliasOrEvmAddress/allowances/tokens
+https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/tokens/tokenId/nfts/serialNumber
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](https://www.notion.so/LICENSE) or (https://www.apache.org/licenses/LICENSE-2.0)

--- a/HIP/hip-xxx.md
+++ b/HIP/hip-xxx.md
@@ -1,5 +1,5 @@
 ---
-hip: xxx
+hip: 980
 title: Enhance mirror node rest APIs with timestamp query parameter
 author: Ivan Kavaldzhiev <ivan.kavaldzhiev@limechain.tech>
 working-group: Steven Sheehy <@steven-sheehy>, Nana Essilfie-Conduah <nana@swirldslabs.com>
@@ -9,7 +9,7 @@ needs-council-approval: Yes
 status: Draft
 created: 2024-06-03
 requested-by: 
-discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/xxx
+discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/981
 ---
 
 ## Abstract


### PR DESCRIPTION
**Description**:
After analyzing the efforts for implementing HIP-980, it was proposed to move the idea of shadow fork support in mirror-node as a rejected idea. That is, because it would have introduced too much REST API calls against public mirror node instances and would harm the performance. In addition, the UX would have included more efforts from a user perspective and wouldn't have been so easy to use.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
