### PR TITLE
Zero Cost EthereumTransaction on Success

### DIFF
--- a/HIP/hip-0000-zero-cost-ethtx-on-success.md
+++ b/HIP/hip-0000-zero-cost-ethtx-on-success.md
@@ -1,0 +1,91 @@
+---
+hip: <HIP number (assigned by the HIP editor), usually the PR number>
+title: Zero Cost EthereumTransaction on Success
+author: Nana Essilfie-Conduah <@Nana-EC>, Richard Bair <@rbair>
+working-group: Richard Bair <@rbair>, Atul Mahamuni <@atul-hedera>, Stanimir Stoyanov <stanimir.stoyanov@limechain.tech>
+requested-by: Relay Operators
+type: Standards Track
+category: Service
+needs-council-approval: Yes
+status: Draft
+created: 2024-11-20
+discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/1083
+updated: 2024-11-20
+requires: [410](https://hips.hedera.com/hip/hip-410)
+---
+
+## Abstract
+
+On many EVM chains execution costs are fully captured in gas. Thus submitting transactions to execution nodes bears no
+cost to the relay node. On Hedera it is necessary to charge a fee for `EthereumTransaction` HAPI submissions (just like
+all other HAPI transactions).
+
+This HIP suggests the network logic not charge successful `EthereumTransaction` submissions, but instead only charge the
+regular HAPI fee for badly formed transactions.
+
+## Motivation
+
+Relay operators must pay the `EthereumTransaction` HAPI fee for every transaction they submit on behalf of an EOA.
+Currently for every `EthereumTransaction` this is the hbar equivalent of $0.0001 based on the exchange rate.
+Though very cheap, this additional HAPI fee charge effectively forces relay operators on Hedera to adopt a business
+model that is more expensive for them than operating on other EVM chains. These costs often get passed onto users
+which inhibits EOA access to low gas fees on Hedera.
+
+This serves as a friction point to EOAs in accessing cheap relay operators on the network.
+
+## Rationale
+
+`EthereumTransaction` HAPI logic charges inner transaction EOAs gas for the transaction execution work.
+As such on every transaction `tx.from` is debited an hbar fee to cover the `gas * gasPrice`.
+This ensures the network does effectively charges for work.
+Thus there is a clear pathway fpr the network to charge a user based on usage making it unnecessary to charge the
+relay operator. However, to encourage relayers to perform prechecks transactions that fail will follow the regular
+HAPI logic and still incur a submission fee.
+
+## User stories
+
+1. As a relay operator I want to submit an `EthereumTransaction` on behalf of an EOA and pay 0 in cryptocurrency costs
+like I do on other EVM chains.
+2. As a relay operator I will pay the HAPI transaction fee for `EthereumTransaction` submissions that fail.
+  
+## Specification
+
+The consensus node HAPI charging logic for `EthereumTransaction` submissions should be updated to the following
+- If the `EthereumTransaction` succeeds do not charge the AccountId submitter
+- If the `EthereumTransaction` fails do charge the AccountId submitter
+
+In both cases the `tx.from` EOA address should be charged the appropriate gas.
+
+## Backwards Compatibility
+
+No changes to transaction execution or record stream externalization is made in this HIP.
+`EthereumTransaction` will continue to work and will only see a reduction in cost on success cases.
+
+## Security Implications
+
+The network maintains a 21k minimum gas expense to the EOA and the equivalent HBAR will be deducted to cover costs.
+Beyond this the EVM and Hedera security model remain in effect.
+
+## How to Teach This
+
+Details on docs.hedera.com
+
+## Reference Implementation
+
+## Rejected Ideas
+
+
+## Open Issues
+
+- [ ] Q: What all avoidable errors could occur to result in a HAPI `EthereumTransaction` e.g. WRONG_NONCE, what else
+
+## References
+
+- [EthereumTransaction protobuf specification](https://github.com/hashgraph/hedera-protobufs/blob/main/services/ethereum_transaction.proto)
+- [Hedera JSON RPC Relay](https://docs.hedera.com/hedera/core-concepts/smart-contracts/json-rpc-relay)
+- [HIP 410](https://hips.hedera.com/hip/hip-410)
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](../LICENSE) or 
+(https://www.apache.org/licenses/LICENSE-2.0)

--- a/HIP/hip-1084.md
+++ b/HIP/hip-1084.md
@@ -10,7 +10,7 @@ needs-council-approval: Yes
 status: Draft
 created: 2024-11-20
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/1083
-updated: 2024-12-06
+updated: 2024-13-06
 requires: 410
 ---
 
@@ -32,14 +32,15 @@ network.
 
 ## Rationale
 
-On Ethereum, all execution costs are paid for by the 'sender' who created, signed, and submitted the transaction. Hedera
-follows a similar approach for all `ContractCallTransaction`s but also charges an additional fee for each
-`EthereumTransaction` submitted via JSON-RPC relays. This fee serves as a defense against a malicious JSON-RPC relay that
-might send malformed transactions to the network, where there would be no one to pay for the processing of those transactions.
-This fee is unnecessary for successful transactions since the intrinsic gas fee covers the base costs (gossip & consensus).
-Therefore, this HIP proposes that the fee for submitting `EthereumTransactions` to the network should only be charged if the
-JSON-RPC relay submits a transaction that fails due diligence checks, such that the EOA cannot be charged for the overhead
-of gossip and consensus.
+On Ethereum, all execution costs are paid for by the 'sender' who created, signed, and submitted the transaction.
+Hedera follows a similar approach for `ContractCallTransaction`s. However, Hedera charges an additional fee for
+each `EthereumTransaction` submitted via JSON-RPC relays. This fee serves as a defense against a malicious
+JSON-RPC relay that might send malformed transactions to the network, where there would be no one to pay for
+the processing of those transactions.
+This fee is unnecessary for successful transactions since the intrinsic gas fee covers the base costs (gossip &
+consensus). Therefore, this HIP proposes that the fee for submitting `EthereumTransactions` to the network
+should only be charged if the JSON-RPC relay submits a transaction that fails due diligence checks, such that the
+EOA cannot be charged for the overhead of gossip and consensus.
 
 ## User stories
 

--- a/HIP/hip-1084.md
+++ b/HIP/hip-1084.md
@@ -10,7 +10,7 @@ needs-council-approval: Yes
 status: Draft
 created: 2024-11-20
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/1083
-updated: 2024-13-06
+updated: 2024-12-17
 requires: 410
 ---
 

--- a/HIP/hip-1084.md
+++ b/HIP/hip-1084.md
@@ -16,7 +16,7 @@ requires: 410
 
 ## Abstract
 
-Updates the rules for charging fees for EthereumTransactions, so that the payer of an EthereumTransaction will only
+Updates the rules for charging fees for EthereumTransactions, so that the payer of an `EthereumTransaction` will only
 incur a fee if the transaction fails due diligence checks.
 
 ## Motivation
@@ -34,7 +34,7 @@ network.
 
 On Ethereum, all execution costs are paid for by the 'sender' who created, signed, and submitted the transaction. Hedera
 follows a similar approach for all `ContractCallTransaction`s but also charges an additional fee for each
-`EthereumTransaction` submitted via JSON-RPC relays. This fee serves as a defense against a malicious JSON-RPC relay tha
+`EthereumTransaction` submitted via JSON-RPC relays. This fee serves as a defense against a malicious JSON-RPC relay that
 might send malformed transactions to the network, where there would be no one to pay for the processing of those transactions.
 This fee is unnecessary for successful transactions since the intrinsic gas fee covers the base costs (gossip & consensus).
 Therefore, this HIP proposes that the fee for submitting `EthereumTransactions` to the network should only be charged if the
@@ -51,11 +51,11 @@ of gossip and consensus.
 ## Specification
 
 Definitions:
- - `evm tx`: the RLP encoded transaction bytes defined by the Ethereum yellow paper that form a standard Ethereum transaction
- - `relay`: a system that, given an `evm tx`, wraps it in an HAPI `EthereumTransaction` and submits it to Hedera.
+ - `evm tx`: The RLP encoded transaction bytes defined by the Ethereum yellow paper that form a standard Ethereum transaction
+ - `relay`: A system that, given an `evm tx`, wraps it in an HAPI `EthereumTransaction` and submits it to Hedera.
             This is also the `payer` for the `EthereumTransaction`. See
             [TransactionBody.transactionID](https://github.com/hashgraph/hedera-protobufs/blob/main/services/transaction_body.proto#L104)
- - `EOA`: the account that created and signed the `evm tx` and submitted it to a `relay`. This is the `from` in the
+ - `EOA`: The account that created and signed the `evm tx` and submitted it to a `relay`. This is the `from` in the
           [Ethereum Transaction Schema](https://github.com/ethereum/execution-apis/blob/main/src/eth/transaction.yaml)
           often noted as (tx.from)
 
@@ -67,7 +67,7 @@ the execution status of the transaction itself once it begins smart contract cre
 
 Examples:
  - The `relay` is charged if the `evm tx` cannot be parsed or is otherwise malformed
- - The `relay` is charged if the `EOA` specified in the `evm tx` refers to a non-existant account
+ - The `relay` is charged if the `EOA` specified in the `evm tx` refers to a non-existent account
  - The `relay` is charged if the `evm tx` was not properly signed by the keys of the `EOA`
  - The `relay` is charged if the `EOA` has insufficient funds to pay the intrinsic gas fee
  - The `relay` is charged if the `nonce` check fails
@@ -76,18 +76,19 @@ Examples:
 
  ### Regular Transactions
 
- A "regular transaction" is a simple HBAR crypto transfer between two accounts. The `relay` will be charged for **any**
- failure of the transaction. This is required to maintain compatibility with the semantics in Ethereum, where a regular transaction 
- will not be included in a block or executed if it will not succeed.
+A "regular transaction" is a simple HBAR crypto transfer between two accounts. The `relay` will be charged for **any**
+failure of the transaction. This is required to maintain compatibility with the semantics in Ethereum, where a regular
+transaction will not be included in a block or executed if it will not succeed.
 
- Example:
- - The `relay` is charged if the `evm tx` cannot be parsed or is otherwise malformed
- - The `relay` is charged if the `EOA` specified in the `evm tx` refers to a non-existant account
- - The `relay` is charged if the `evm tx` was not properly signed by the keys of the `EOA`
- - The `relay` is charged if the `EOA` has insufficient funds to pay the intrinsic gas fee **and** the transfer
- - The `relay` is charged if the receiver has `receiverSigRequired` enabled
- - The `relay` is charged if the receiver doesn't exist, must be auto-created, and the `EOA` has insufficient funds to pay for the account creation
- - The `relay` is charged if the `nonce` check fails
+Example:
+- The `relay` is charged if the `evm tx` cannot be parsed or is otherwise malformed
+- The `relay` is charged if the `EOA` specified in the `evm tx` refers to a non-existent account
+- The `relay` is charged if the `evm tx` was not properly signed by the keys of the `EOA`
+- The `relay` is charged if the `EOA` has insufficient funds to pay the intrinsic gas fee **and** the transfer
+- The `relay` is charged if the receiver has `receiverSigRequired` enabled
+- The `relay` is charged if the receiver doesn't exist, must be auto-created, and the `EOA` has insufficient funds to
+    pay for the account creation
+- The `relay` is charged if the `nonce` check fails
 
 ## Backwards Compatibility
 

--- a/HIP/hip-1084.md
+++ b/HIP/hip-1084.md
@@ -1,5 +1,5 @@
 ---
-hip: <HIP number (assigned by the HIP editor), usually the PR number>
+hip: 1084
 title: Zero Cost EthereumTransaction on Success
 author: Nana Essilfie-Conduah <@Nana-EC>, Richard Bair <@rbair>
 working-group: Richard Bair <@rbair>, Atul Mahamuni <@atul-hedera>, Stanimir Stoyanov <stanimir.stoyanov@limechain.tech>

--- a/HIP/hip-1084.md
+++ b/HIP/hip-1084.md
@@ -11,7 +11,7 @@ status: Draft
 created: 2024-11-20
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/1083
 updated: 2024-11-20
-requires: [410](https://hips.hedera.com/hip/hip-410)
+requires: 410
 ---
 
 ## Abstract

--- a/HIP/hip-1084.md
+++ b/HIP/hip-1084.md
@@ -50,13 +50,21 @@ like I do on other EVM chains.
   
 ## Specification
 
-The consensus node HAPI charging logic for `EthereumTransaction` submissions should be updated to the following
-- If the `EthereumTransaction` succeeds do not charge the AccountId submitter
-- If the `EthereumTransaction` fails do charge the AccountId submitter
+Each `EthereumTransaction` involves 2 accounts for consideration in charging fees.
+1. The top level AccountId noted in the [TransactionBody.transactionID](https://github.com/hashgraph/hedera-protobufs/blob/main/services/transaction_body.proto#L104)
+    - this is usually the relay account that submits a transaction on behalf of an EOA.
+2. The EOA address noted in the inner RLP encoded transaction - this is the address value in `from` in the
+[Ethereum Transaction Schema](https://github.com/ethereum/execution-apis/blob/main/src/eth/transaction.yaml) often noted as (tx.from)
 
-In both cases the `tx.from` EOA address should be charged the appropriate gas.
+A valid Hedera account represented by `tx.from` is always charged the hbar equivalent of the gas needed for execution
+once the EVM execution flow is initiated. This is regardless of whether the EVM execution succeeds or fails.
+As part of the nodes transaction validation logic, a check is done to confirm that the `tx.from` account is valid and
+has sufficient balance. If not the transaction fails to reach EVM execution.
 
-The inner transaction should be parseable and well formed, otherwise it is a due diligence failure.
+The consensus node HAPI charging logic for `EthereumTransaction` submissions should therefore be updated to the following
+- If the `EthereumTransaction` succeeds in initiate the EVM execution logic, do not charge the relay AccountId submitter
+- If the EthereumTransaction fails to initiative the EVM execution logic, do charge the relay AccountId submitter. Examples here are unparsable or ill formed transactions, or insufficient balance at the time of execution.
+- Continue to charge the inner transaction `tx.from` EOA account gas if valid in both the success and failure scenario.
 
 ## Backwards Compatibility
 

--- a/HIP/hip-1084.md
+++ b/HIP/hip-1084.md
@@ -10,7 +10,7 @@ needs-council-approval: Yes
 status: Draft
 created: 2024-11-20
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/1083
-updated: 2024-11-20
+updated: 2024-12-06
 requires: 410
 ---
 
@@ -74,6 +74,10 @@ Examples:
  - The `relay` is not charged if the contract is called but concludes with an error code 
  - The `relay` is not charged if the contract is called and concludes without error
 
+In summary the `relay` account is not charged if the `EthereumTransaction` transaction completes in a 
+`CONTRACT_REVERT_EXECUTED` or `SUCCESS` HAPI response code, all other responses codes will result in a charge to the
+relay account.
+
  ### Regular Transactions
 
 A "regular transaction" is a simple HBAR crypto transfer between two accounts. The `relay` will be charged for **any**
@@ -90,10 +94,13 @@ Example:
     pay for the account creation
 - The `relay` is charged if the `nonce` check fails
 
+In summary the `relay` account is not charged if the `EthereumTransaction` transaction completes in a `SUCCESS`
+HAPI response code, all other response codes will result in a charge to the `relay` account.
+
 ## Backwards Compatibility
 
 No changes to transaction execution or record stream externalization is made in this HIP.
-`EthereumTransaction` will continue to work and will only see a reduction in cost on success cases.
+`EthereumTransaction` will continue to work and will only see a reduction in cost on success or contract revert cases.
 
 ## Security Implications
 

--- a/HIP/hip-1084.md
+++ b/HIP/hip-1084.md
@@ -7,10 +7,11 @@ requested-by: Relay Operators
 type: Standards Track
 category: Service
 needs-council-approval: Yes
-status: Draft
+status: Last Call
+last-call-date-time: 2025-01-29T07:00:00Z
 created: 2024-11-20
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/1083
-updated: 2024-12-17
+updated: 2024-01-15
 requires: 410
 ---
 

--- a/HIP/hip-1084.md
+++ b/HIP/hip-1084.md
@@ -56,6 +56,8 @@ The consensus node HAPI charging logic for `EthereumTransaction` submissions sho
 
 In both cases the `tx.from` EOA address should be charged the appropriate gas.
 
+The inner transaction should be parseable and well formed, otherwise it is a due diligence failure.
+
 ## Backwards Compatibility
 
 No changes to transaction execution or record stream externalization is made in this HIP.

--- a/HIP/hip-1084.md
+++ b/HIP/hip-1084.md
@@ -11,7 +11,7 @@ status: Last Call
 last-call-date-time: 2025-01-29T07:00:00Z
 created: 2024-11-20
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/1083
-updated: 2024-01-15
+updated: 2025-01-15
 requires: 410
 ---
 


### PR DESCRIPTION
**Description**:
On many EVM chains execution costs are fully captured in gas. Thus submitting transactions to execution nodes bears no
cost to the relay node. On Hedera it is necessary to charge a fee for `EthereumTransaction` HAPI submissions (just like
all other HAPI transactions).

This HIP suggests the network logic not charge successful `EthereumTransaction` submissions, but instead only charge the
regular HAPI fee for badly formed transactions.

**Related issue(s)**:

Fixes #1083 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
