### PR TITLE
Display pr draft hips

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,5 @@
 <head>
+    <meta name="github-token" content="{{ site.env.GITHUB_TOKEN }}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css" rel="stylesheet" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <meta charset="UTF-8">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <head>
-    <meta name="github-token" content="{{ site.env.GITHUB_TOKEN }}">
+    <meta name="github-token" content="{{ secrets.GITHUB_TOKEN }}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css" rel="stylesheet" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <meta charset="UTF-8">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <head>
-    <meta name="github-token" content="{{ secrets.GITHUB_TOKEN }}">
+    <meta name="github-token" content="{{ secrets.DRAFT_HIPS }}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css" rel="stylesheet" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <meta charset="UTF-8">

--- a/_includes/hipstable.md
+++ b/_includes/hipstable.md
@@ -46,7 +46,7 @@
 
 <!-- First render the draft section -->
 <h2 id="draft">Draft <span class="status-tooltip" data-tooltip="Draft">ⓘ</span></h2>
-<table class="hipstable">
+<table class="hipstable draft-table">
     <thead>
         <tr>
             <th class="numeric">Number</th>
@@ -55,9 +55,7 @@
             <th>Needs Council Approval</th>
         </tr>
     </thead>
-    <tbody class="draft-tbody">
-        <!-- JavaScript will populate this section -->
-    </tbody>
+    <tbody class="draft-tbody"></tbody>
 </table>
 
 <!-- Then render the rest of the statuses -->

--- a/_includes/hipstable.md
+++ b/_includes/hipstable.md
@@ -10,9 +10,11 @@
             <option value="process">Process</option>
         </select>
     </div>
+    
     <div class="filter-group">
         <h4>Status&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</h4>
         <select id="status-filter" class="status-filter" multiple>
+            <option value="draft">Draft</option>
             <option value="review">Review</option>
             <option value="last call">Last Call</option>
             <option value="council review">Council Review</option>
@@ -26,18 +28,24 @@
             <option value="withdrawn">Withdrawn</option>
         </select>
     </div>
+    
     <div class="filter-group">
         <h4>Council Approval&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</h4>
-        <label><input type="radio" name="council-approval-filter" class="council-filter" value="true"> Yes</label>
-        <label><input type="radio" name="council-approval-filter" class="council-filter" value="false"> No</label>
+        <label>
+            <input type="radio" name="council-approval-filter" class="council-filter" value="true"> Yes
+        </label>
+        <label>
+            <input type="radio" name="council-approval-filter" class="council-filter" value="false"> No
+        </label>
     </div>
 </div>
-<div class="no-hips-message" style="display: none;">No HIPs exist for this filter.</div>
-{% for status in site.data.statuses %}
-{% assign hips = include.hips | where: "status", status | where: "category", category | where: "type", type | sort: "hip" | reverse %}
-{% assign count = hips.size %}
-{% if count > 0 %}
-<h2 id="{{ status | slugify }}">{{ status }} <span class="status-tooltip" data-tooltip="{{ status }}">ⓘ</span></h2>
+
+<div class="no-hips-message" style="display: none;">
+    No HIPs exist for this filter.
+</div>
+
+<!-- First render the draft section -->
+<h2 id="draft">Draft <span class="status-tooltip" data-tooltip="Draft">ⓘ</span></h2>
 <table class="hipstable">
     <thead>
         <tr>
@@ -45,38 +53,87 @@
             <th>Title</th>
             <th>Author</th>
             <th>Needs Council Approval</th>
-            {% if status == "Last Call" %}
-            <th>Review Period Ends</th>
-            {% else %}
             <th class="numeric version">Release</th>
-            {% endif %}
         </tr>
     </thead>
-    <tbody>
-        {% for page in hips %}
-        <tr data-type="{{ page.type | downcase }}" data-category="{{ page.category | downcase }}" data-status="{{ page.status | downcase }}" data-council-approval="{{ page.needs-council-approval | downcase }}">
-            <td class="hip-number"><a href="{{ page.url | relative_url }}">{{ page.hip | xml_escape }}</a></td>
-            <td class="title"><a href="{{ page.url | relative_url }}">{{ page.title | xml_escape }}</a></td>
-            <td class="author">{% include authorslist.html authors=page.author %}</td>
-            <td class="council-approval">
-                {% if page.needs-council-approval %}
-                    Yes
-                {% else %}
-                    No
-                {% endif %}
-            </td>
-            {% if status == "Last Call" %}
-            <td class="last-call-date-time">{{ page.last-call-date-time | date_to_rfc822 }}</td>
-            {% else %}
-                    {% if page.category == "Mirror" %}
-                    <td class="release"><a href="https://github.com/hashgraph/hedera-mirror-node/releases/tag/{{page.release}}">{{page.release|xml_escape}}</a></td>
-                    {% else %}
-                    <td class="release"><a href="https://github.com/hashgraph/hedera-services/releases/tag/{{page.release}}">{{page.release|xml_escape}}</a></td>
-                {% endif %}
-            {% endif %}
-        </tr>
-        {% endfor %}
+    <tbody class="draft-tbody">
+        <!-- JavaScript will populate this section -->
     </tbody>
 </table>
-{% endif %}
+
+<!-- Then render the rest of the statuses -->
+{% for status in site.data.statuses %}
+    {% assign hips = include.hips | where: "status", status | where: "category", category | where: "type", type | sort: "hip" | reverse %}
+    {% assign count = hips.size %}
+    {% if count > 0 %}
+        <h2 id="{{ status | slugify }}">
+            {{ status | capitalize }} 
+            <span class="status-tooltip" data-tooltip="{{ status }}">ⓘ</span>
+        </h2>
+        
+        <table class="hipstable">
+            <thead>
+                <tr>
+                    <th class="numeric">Number</th>
+                    <th>Title</th>
+                    <th>Author</th>
+                    <th>Needs Council Approval</th>
+                    {% if status == "Last Call" %}
+                        <th>Review Period Ends</th>
+                    {% else %}
+                        <th class="numeric version">Release</th>
+                    {% endif %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for page in hips %}
+                    <tr data-type="{{ page.type | downcase }}"
+                        data-category="{{ page.category | downcase }}"
+                        data-status="{{ page.status | downcase }}"
+                        data-council-approval="{{ page.needs-council-approval | downcase }}">
+                        
+                        <td class="hip-number">
+                            <a href="{{ page.url | relative_url }}">{{ page.hip | xml_escape }}</a>
+                        </td>
+                        
+                        <td class="title">
+                            <a href="{{ page.url | relative_url }}">{{ page.title | xml_escape }}</a>
+                        </td>
+                        
+                        <td class="author">
+                            {% include authorslist.html authors=page.author %}
+                        </td>
+                        
+                        <td class="council-approval">
+                            {% if page.needs-council-approval %}
+                                Yes
+                            {% else %}
+                                No
+                            {% endif %}
+                        </td>
+                        
+                        {% if status == "Last Call" %}
+                            <td class="last-call-date-time">
+                                {{ page.last-call-date-time | date_to_rfc822 }}
+                            </td>
+                        {% else %}
+                            {% if page.category == "Mirror" %}
+                                <td class="release">
+                                    <a href="https://github.com/hashgraph/hedera-mirror-node/releases/tag/{{page.release}}">
+                                        {{page.release|xml_escape}}
+                                    </a>
+                                </td>
+                            {% else %}
+                                <td class="release">
+                                    <a href="https://github.com/hashgraph/hedera-services/releases/tag/{{page.release}}">
+                                        {{page.release|xml_escape}}
+                                    </a>
+                                </td>
+                            {% endif %}
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
 {% endfor %}

--- a/_includes/hipstable.md
+++ b/_includes/hipstable.md
@@ -53,7 +53,6 @@
             <th>Title</th>
             <th>Author</th>
             <th>Needs Council Approval</th>
-            <th class="numeric version">Release</th>
         </tr>
     </thead>
     <tbody class="draft-tbody">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,9 +13,11 @@
 </main>
 
 {%- include footer.html -%}
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="{{ '/assets/js/tooltip.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/hipstable.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/filter.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/pr-integration.js' | relative_url }}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.min.js"></script>
 </body>
 

--- a/assets/js/pr-integration.js
+++ b/assets/js/pr-integration.js
@@ -1,6 +1,5 @@
 class HIPPRIntegration {
     constructor() {
-        console.log('HIPPRIntegration initialized');
         this.initialize();
         this.setupStyles();
     }
@@ -69,99 +68,105 @@ class HIPPRIntegration {
     }
 
     async fetchPRData() {
-        const token = document.querySelector('meta[name="github-token"]').content;
-        const query = {
-            query: `query { 
-                repository(name: "hedera-improvement-proposal", owner: "hashgraph") {
-                    pullRequests(first: 100, orderBy: {field: CREATED_AT, direction: DESC}, states: [OPEN]) {
-                        nodes {
-                            title
-                            number
-                            url
-                            headRefOid
-                            files(last: 100) {
-                                edges {
-                                    node {
-                                        path
-                                        additions
-                                        deletions
+        try {
+            const token = document.querySelector('meta[name="github-token"]').content;
+
+            const query = {
+                query: `query { 
+                    repository(name: "hedera-improvement-proposal", owner: "hashgraph") {
+                        pullRequests(first: 100, orderBy: {field: CREATED_AT, direction: DESC}, states: [OPEN]) {
+                            nodes {
+                                title
+                                number
+                                url
+                                headRefOid
+                                files(last: 100) {
+                                    edges {
+                                        node {
+                                            path
+                                            additions
+                                            deletions
+                                        }
                                     }
                                 }
-                            }
-                            author {
-                                login
+                                author {
+                                    login
+                                }
                             }
                         }
                     }
-                }
-            }`
-        };
+                }`
+            };
 
-        const response = await fetch('https://api.github.com/graphql', {
-            method: 'POST',
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(query)
-        });
+            const response = await fetch('https://api.github.com/graphql', {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(query)
+            });
 
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+            const data = await response.json();
+
+            if (!response.ok || data.errors) {
+                console.error('GraphQL errors:', data.errors);
+                return null;
+            }
+            return data.data.repository.pullRequests.nodes;
+        } catch (error) {
+            console.error('Error in fetchPRData:', error);
+            throw error;
         }
-
-        const data = await response.json();
-        if (data.errors) {
-            console.error('GraphQL returned errors:', data.errors);
-            return null;
-        }
-        return data.data.repository.pullRequests.nodes;
     }
 
     async filterHIPPRs(prs) {
         const validHips = [];
         const seenPRs = new Set();
-
+    
         for (const pr of prs) {
             if (seenPRs.has(pr.number)) continue;
-
+    
             const mdFiles = pr.files.edges.filter(file => file.node.path.endsWith('.md'));
-
+            let bestMetadata = null;
+            let bestFile = null;
+    
+            // Try all MD files and pick the one with the most complete metadata
             for (const file of mdFiles) {
                 try {
                     const contentUrl = `https://raw.githubusercontent.com/hashgraph/hedera-improvement-proposal/${pr.headRefOid}/${file.node.path}`;
                     const response = await fetch(contentUrl);
                     const content = await response.text();
-
                     const metadata = this.parseHIPMetadata(content);
-
-                    // Skip if title is missing, empty, a template placeholder, or exactly "No"
-                    if (!metadata.title ||
-                        metadata.title.trim() === '' ||
-                        metadata.title === 'No' ||
-                        metadata.title.includes('<') ||
-                        metadata.title.includes('>') ||
-                        metadata.title === '<HIP title>') {
+    
+                    // Skip template files and empty metadata
+                    if (file.node.path.includes('template') || !metadata.title) {
                         continue;
                     }
-
-                    const isNewHip = this.checkForNewHipFormat(content);
-
-                    if (isNewHip && this.isValidHIPContent(metadata)) {
-                        validHips.push({
-                            pr,
-                            metadata,
-                            filePath: file.node.path
-                        });
-                        seenPRs.add(pr.number);
-                        break;
+    
+                    // If we don't have metadata yet, or this file has a better title
+                    if (!bestMetadata || 
+                        (metadata.title && metadata.title.length > 3 && 
+                         (!bestMetadata.title || metadata.title.length > bestMetadata.title.length))) {
+                        bestMetadata = metadata;
+                        bestFile = file;
                     }
                 } catch (error) {
                     console.error(`Error checking file ${file.node.path}:`, error);
                 }
             }
+    
+            // If we found valid metadata, add it to the results
+            if (bestMetadata && bestFile) {
+                validHips.push({
+                    pr,
+                    metadata: bestMetadata,
+                    filePath: bestFile.node.path
+                });
+                seenPRs.add(pr.number);
+            }
         }
-
+    
         return validHips;
     }
 
@@ -221,7 +226,6 @@ class HIPPRIntegration {
                         <th>Title</th>
                         <th>Author</th>
                         <th>Needs Council Approval</th>
-                        <th class="numeric version">Release</th>
                     </tr>
                 </thead>
                 <tbody></tbody>
@@ -230,31 +234,89 @@ class HIPPRIntegration {
 
         wrapper.insertBefore(draftContainer, lastStatusSection.nextSibling);
         const tbody = draftContainer.querySelector('tbody');
+        const table = draftContainer.querySelector('.hipstable');
 
         hips.forEach(({ pr, metadata }) => {
-            // Additional title validation before creating row
-            if (!metadata.title ||
-                metadata.title.trim() === '' ||
-                metadata.title === 'No' ||
-                !pr.title) {
-                return;
-            }
+            if (!metadata.title || metadata.title.trim() === '') return;
+
+            const needsApproval = String(metadata['needs-council-approval']).toLowerCase() === 'true' ||
+                String(metadata['needs-tsc-approval']).toLowerCase() === 'true' ||
+                String(metadata.needs_council_approval).toLowerCase() === 'true' ||
+                metadata.type?.toLowerCase() === 'standards track';
 
             const row = document.createElement('tr');
             row.dataset.type = (metadata.type || 'core').toLowerCase();
             row.dataset.status = 'draft';
-            row.dataset.councilApproval = 'false';
+            row.dataset.councilApproval = needsApproval.toString();
             row.dataset.category = metadata.category || '';
+
+            const authors = metadata.author.split(',').map(author => {
+                const match = author.trim().match(/([^<(]+)(?:[<(]([^>)]+)[>)])?/);
+                if (!match) return author.trim();
+
+                const name = match[1].trim();
+                const linkInfo = match[2]?.trim();
+
+                if (linkInfo) {
+                    if (linkInfo.startsWith('@')) {
+                        const username = linkInfo.substring(1);
+                        return `<a href="https://github.com/${username}">${name}</a>`;
+                    } else if (linkInfo.includes('@')) {
+                        return `<a href="mailto:${linkInfo}">${name}</a>`;
+                    }
+                }
+                return name;
+            });
 
             row.innerHTML = `
                 <td class="hip-number"><a href="${pr.url}" target="_blank">PR-${pr.number}</a></td>
                 <td class="title"><a href="${pr.url}" target="_blank">${metadata.title}</a></td>
-                <td class="author">${metadata.author || pr.author.login}</td>
-                <td class="council-approval">No</td>
-                <td class="release">Draft</td>
+                <td class="author">${authors.join(', ')}</td>
+                <td class="council-approval">${needsApproval ? 'Yes' : 'No'}</td>
             `;
 
             tbody.appendChild(row);
+        });
+
+        table.querySelectorAll('th').forEach(header => {
+            header.addEventListener('click', function () {
+                const tbody = table.querySelector('tbody');
+                const index = Array.from(header.parentNode.children).indexOf(header);
+                const isAscending = header.classList.contains('asc');
+                const isNumeric = header.classList.contains('numeric');
+                const isVersion = header.classList.contains('version');
+
+                Array.from(tbody.querySelectorAll('tr'))
+                    .sort((rowA, rowB) => {
+                        let cellA = rowA.querySelectorAll('td')[index].textContent;
+                        let cellB = rowB.querySelectorAll('td')[index].textContent;
+
+                        if (isNumeric && cellA.startsWith('PR-') && cellB.startsWith('PR-')) {
+                            // Extract numbers from PR-XXX format
+                            const numA = parseInt(cellA.replace('PR-', ''));
+                            const numB = parseInt(cellB.replace('PR-', ''));
+                            return (numA - numB) * (isAscending ? 1 : -1);
+                        }
+
+                        // Version sorting logic
+                        if (isVersion) {
+                            cellA = cellA.replace('v', '').split('.').map(Number);
+                            cellB = cellB.replace('v', '').split('.').map(Number);
+                            return cellA > cellB ? (isAscending ? 1 : -1) : cellA < cellB ? (isAscending ? -1 : 1) : 0;
+                        }
+
+                        // Default sorting logic
+                        return isNumeric ? (parseFloat(cellA) - parseFloat(cellB)) * (isAscending ? 1 : -1) : cellA.localeCompare(cellB) * (isAscending ? 1 : -1);
+                    })
+                    .forEach(tr => tbody.appendChild(tr));
+
+                header.classList.toggle('asc', !isAscending);
+                header.classList.toggle('desc', isAscending);
+
+                Array.from(header.parentNode.children)
+                    .filter(th => th !== header)
+                    .forEach(th => th.classList.remove('asc', 'desc'));
+            });
         });
     }
 }

--- a/assets/js/pr-integration.js
+++ b/assets/js/pr-integration.js
@@ -1,0 +1,264 @@
+class HIPPRIntegration {
+    constructor() {
+        console.log('HIPPRIntegration initialized');
+        this.initialize();
+        this.setupStyles();
+    }
+
+    setupStyles() {
+        const styles = `
+            .hip-modal {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                background: rgba(0, 0, 0, 0.7);
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                z-index: 1000;
+            }
+            .hip-modal-content {
+                background: white;
+                padding: 20px;
+                border-radius: 8px;
+                max-width: 80%;
+                max-height: 80vh;
+                overflow-y: auto;
+                position: relative;
+            }
+            .hip-modal-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                margin-bottom: 20px;
+                border-bottom: 1px solid #eee;
+                padding-bottom: 10px;
+            }
+            .close-button {
+                background: none;
+                border: none;
+                font-size: 24px;
+                cursor: pointer;
+            }
+            .hip-modal-body {
+                line-height: 1.6;
+            }
+            .hip-modal-body img {
+                max-width: 100%;
+            }
+        `;
+        const styleSheet = document.createElement('style');
+        styleSheet.textContent = styles;
+        document.head.appendChild(styleSheet);
+    }
+
+    async initialize() {
+        try {
+            const prData = await this.fetchPRData();
+            if (prData) {
+                const validHips = await this.filterHIPPRs(prData);
+                if (validHips.length > 0) {
+                    this.addHIPsToTable(validHips);
+                }
+            }
+        } catch (error) {
+            console.error('Failed to initialize PR integration:', error);
+        }
+    }
+
+    async fetchPRData() {
+        const token = document.querySelector('meta[name="github-token"]').content;
+        const query = {
+            query: `query { 
+                repository(name: "hedera-improvement-proposal", owner: "hashgraph") {
+                    pullRequests(first: 100, orderBy: {field: CREATED_AT, direction: DESC}, states: [OPEN]) {
+                        nodes {
+                            title
+                            number
+                            url
+                            headRefOid
+                            files(last: 100) {
+                                edges {
+                                    node {
+                                        path
+                                        additions
+                                        deletions
+                                    }
+                                }
+                            }
+                            author {
+                                login
+                            }
+                        }
+                    }
+                }
+            }`
+        };
+
+        const response = await fetch('https://api.github.com/graphql', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(query)
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const data = await response.json();
+        if (data.errors) {
+            console.error('GraphQL returned errors:', data.errors);
+            return null;
+        }
+        return data.data.repository.pullRequests.nodes;
+    }
+
+    async filterHIPPRs(prs) {
+        const validHips = [];
+        const seenPRs = new Set();
+
+        for (const pr of prs) {
+            if (seenPRs.has(pr.number)) continue;
+
+            const mdFiles = pr.files.edges.filter(file => file.node.path.endsWith('.md'));
+
+            for (const file of mdFiles) {
+                try {
+                    const contentUrl = `https://raw.githubusercontent.com/hashgraph/hedera-improvement-proposal/${pr.headRefOid}/${file.node.path}`;
+                    const response = await fetch(contentUrl);
+                    const content = await response.text();
+
+                    const metadata = this.parseHIPMetadata(content);
+
+                    // Skip if title is missing, empty, a template placeholder, or exactly "No"
+                    if (!metadata.title ||
+                        metadata.title.trim() === '' ||
+                        metadata.title === 'No' ||
+                        metadata.title.includes('<') ||
+                        metadata.title.includes('>') ||
+                        metadata.title === '<HIP title>') {
+                        continue;
+                    }
+
+                    const isNewHip = this.checkForNewHipFormat(content);
+
+                    if (isNewHip && this.isValidHIPContent(metadata)) {
+                        validHips.push({
+                            pr,
+                            metadata,
+                            filePath: file.node.path
+                        });
+                        seenPRs.add(pr.number);
+                        break;
+                    }
+                } catch (error) {
+                    console.error(`Error checking file ${file.node.path}:`, error);
+                }
+            }
+        }
+
+        return validHips;
+    }
+
+    checkForNewHipFormat(content) {
+        const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
+        if (!frontmatterMatch) return false;
+
+        const frontmatter = frontmatterMatch[1].toLowerCase();
+        const requiredPatterns = [
+            /\btitle\s*:/,
+            /\bauthor\s*:/,
+            /\bcategory\s*:/,
+            /\bcreated\s*:/
+        ];
+
+        return requiredPatterns.every(pattern => pattern.test(frontmatter));
+    }
+
+    isValidHIPContent(metadata) {
+        const essentialFields = ['title', 'type'];
+        const hasEssentialFields = essentialFields.every(field => metadata[field]);
+        const desiredFields = ['hip', 'author', 'status', 'created'];
+        const desiredFieldCount = desiredFields.filter(field => metadata[field]).length;
+        return hasEssentialFields && desiredFieldCount >= 2;
+    }
+
+    parseHIPMetadata(content) {
+        const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
+        if (!frontmatterMatch) return {};
+
+        const metadata = {};
+        const lines = frontmatterMatch[1].split('\n');
+
+        for (const line of lines) {
+            const [key, ...valueParts] = line.split(':');
+            if (key && valueParts.length) {
+                const value = valueParts.join(':').trim();
+                metadata[key.trim().toLowerCase()] = value;
+            }
+        }
+
+        return metadata;
+    }
+
+    addHIPsToTable(hips) {
+        const wrapper = document.querySelector('main .wrapper');
+        if (!wrapper) return;
+
+        const lastStatusSection = wrapper.lastElementChild;
+        const draftContainer = document.createElement('div');
+        draftContainer.innerHTML = `
+            <h2 id="draft">Draft <span class="status-tooltip" data-tooltip="Draft">ⓘ</span></h2>
+            <table class="hipstable">
+                <thead>
+                    <tr>
+                        <th class="numeric">Number</th>
+                        <th>Title</th>
+                        <th>Author</th>
+                        <th>Needs Council Approval</th>
+                        <th class="numeric version">Release</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        `;
+
+        wrapper.insertBefore(draftContainer, lastStatusSection.nextSibling);
+        const tbody = draftContainer.querySelector('tbody');
+
+        hips.forEach(({ pr, metadata }) => {
+            // Additional title validation before creating row
+            if (!metadata.title ||
+                metadata.title.trim() === '' ||
+                metadata.title === 'No' ||
+                !pr.title) {
+                return;
+            }
+
+            const row = document.createElement('tr');
+            row.dataset.type = (metadata.type || 'core').toLowerCase();
+            row.dataset.status = 'draft';
+            row.dataset.councilApproval = 'false';
+            row.dataset.category = metadata.category || '';
+
+            row.innerHTML = `
+                <td class="hip-number"><a href="${pr.url}" target="_blank">PR-${pr.number}</a></td>
+                <td class="title"><a href="${pr.url}" target="_blank">${metadata.title}</a></td>
+                <td class="author">${metadata.author || pr.author.login}</td>
+                <td class="council-approval">No</td>
+                <td class="release">Draft</td>
+            `;
+
+            tbody.appendChild(row);
+        });
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    new HIPPRIntegration();
+});


### PR DESCRIPTION
**Description**:
Added functionality to display open Pull Requests as Draft HIPs on hips.hedera.com, enabling early visibility of proposed improvements. Draft HIPs appear in a dedicated section on the main page, showing PR titles, authors, and status. Each entry links directly to its GitHub PR, connecting users to active discussions and development. Implemented frontmatter validation to identify and display valid Draft HIPs while maintaining existing table structure and filtering capabilities.
