### PR TITLE
chore: remove devops-ci-committers from CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/devops-ci @devops-ci-committers
+/.github/workflows/                             @hashgraph/devops-ci
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                      @hashgraph/release-engineering-managers


### PR DESCRIPTION
**Description**:

Remove the `devops-ci-committers` from CODEOWNERS file as this group does not have access to the repo.

**Related issue(s)**:

No related issue as issues are disabled on this repo.
