### PR TITLE
chore: add product managers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners for entire repository
-*   @mgarbs
+*   @hashgraph/product-management @mgarbs
 
 #########################
 #####  Core Files  ######


### PR DESCRIPTION
**Description**:

Add `@hashgraph/product-management` to the CODEOWNERS file.
