### PR TITLE
Add HIP to allow the deletion of allowances without being associated

### DIFF
--- a/HIP/hip-1126.md
+++ b/HIP/hip-1126.md
@@ -1,5 +1,5 @@
 ---
-hip: <HIP number (assigned by the HIP editor), usually the PR number>
+hip: 1126
 title: "Delete Allowance without Token Association"
 author: Michael Heinrichs <@netopyr>
 working-group:

--- a/HIP/hip-1126.md
+++ b/HIP/hip-1126.md
@@ -10,7 +10,7 @@ needs-council-approval: "Yes"
 status: "Draft"
 created: 2025-02-17
 discussions-to: https://github.com/hiero-ledger/hiero-consensus-node/issues/17441
-updated: 2025-02-17
+updated: 2025-02-24
 requires: 
 replaces: 
 superseded-by: 
@@ -29,8 +29,9 @@ A user may decide to keep the allowances instead, which wastes resources and ris
 While it makes sense to associate the token before giving a non-zero allowance, it does not make sense that the token must be associated in order for the allowance to be removed.
 
 ## Rationale
-The execution of `CryptoDeleteAllowance` does not require the owner to have an association with the token.
-If `CryptoApproveAllowance` contains an entry for a fungible token and an amount of `0`, the owner does not require an association with the token.
+`CryptoDeleteAllowance` is used to delete allowances on NFTs. Once this HIP is implemented, it does not require the owner to have an association with the token.
+
+To delete the allowance of a fungible token, a user has to send a `CryptoApproveAllowance` with an amount of `0`. After this HIP is implemented, the owner does not require an association with the fungible token to execute this transaction.
 
 ## User stories
 1. As a user, I want to remove an allowance without having to associate the token with my account first.

--- a/HIP/hip-1126.md
+++ b/HIP/hip-1126.md
@@ -2,7 +2,6 @@
 hip: 1126
 title: Delete Allowance without Token Association
 author: Michael Heinrichs <@netopyr>
-working-group:
 requested-by: GitHub issue https://github.com/hiero-ledger/hiero-consensus-node/issues/17441
 type: Standards Track
 category: Service

--- a/HIP/hip-1126.md
+++ b/HIP/hip-1126.md
@@ -1,19 +1,16 @@
 ---
 hip: 1126
-title: "Delete Allowance without Token Association"
+title: Delete Allowance without Token Association
 author: Michael Heinrichs <@netopyr>
 working-group:
 requested-by: GitHub issue https://github.com/hiero-ledger/hiero-consensus-node/issues/17441
-type: "Standards Track"
-category: "Service"
-needs-council-approval: "Yes"
-status: "Draft"
+type: Standards Track
+category: Service
+needs-council-approval: Yes
+status: Draft
 created: 2025-02-17
 discussions-to: https://github.com/hiero-ledger/hiero-consensus-node/issues/17441
-updated: 2025-02-24
-requires: 
-replaces: 
-superseded-by: 
+updated: 2025-03-03
 ---
 
 ## Abstract

--- a/HIP/hip-1126.md
+++ b/HIP/hip-1126.md
@@ -6,7 +6,8 @@ requested-by: GitHub issue https://github.com/hiero-ledger/hiero-consensus-node/
 type: Standards Track
 category: Service
 needs-council-approval: Yes
-status: Draft
+status: Last Call
+last-call-date-time: 2025-03-17T07:00:00Z
 created: 2025-02-17
 discussions-to: https://github.com/hiero-ledger/hiero-consensus-node/issues/17441
 updated: 2025-03-03

--- a/_data/draft_hips.json
+++ b/_data/draft_hips.json
@@ -1,5 +1,53 @@
 [
   {
+    "title": "Bump step-security/harden-runner from 2.10.4 to 2.11.0",
+    "number": 1125,
+    "url": "https://github.com/hashgraph/hedera-improvement-proposal/pull/1125",
+    "headRefOid": "5c4f4ee479920578fcff01ae89114ea6bf20e55b",
+    "files": {
+      "edges": [
+        {
+          "node": {
+            "path": ".github/workflows/add-hip-number.yml",
+            "additions": 1,
+            "deletions": 1
+          }
+        },
+        {
+          "node": {
+            "path": ".github/workflows/notifications.yml",
+            "additions": 1,
+            "deletions": 1
+          }
+        },
+        {
+          "node": {
+            "path": ".github/workflows/send-discord-message.yml",
+            "additions": 1,
+            "deletions": 1
+          }
+        },
+        {
+          "node": {
+            "path": ".github/workflows/send-email.yml",
+            "additions": 1,
+            "deletions": 1
+          }
+        },
+        {
+          "node": {
+            "path": ".github/workflows/validateHeaders.yml",
+            "additions": 1,
+            "deletions": 1
+          }
+        }
+      ]
+    },
+    "author": {
+      "login": "dependabot"
+    }
+  },
+  {
     "title": "chore:update HIP 1028 reflecting versioning",
     "number": 1124,
     "url": "https://github.com/hashgraph/hedera-improvement-proposal/pull/1124",


### PR DESCRIPTION
**Description**:

This PR adds the first draft of a HIP to allow the deletion of token allowances for tokens that are not associated with the account anymore. This was requested by the community in the form of a [GitHub issue](https://github.com/hiero-ledger/hiero-consensus-node/issues/17441).

