### PR TITLE
Updating `ContractCreate` limits

### DIFF
--- a/HIP/hip-1086.md
+++ b/HIP/hip-1086.md
@@ -3,7 +3,7 @@ hip: 1086
 title: Jumbo EthereumTransaction
 author: Nana Essilfie-Conduah <@Nana-EC>, Richard Bair <@rbair>
 working-group: Richard Bair <@rbair>, Atul Mahamuni <@atul-hedera>, Leemon Baird <leemon@hedera.com>,
-Joseph Sinclair<@jsync-swirlds>
+  Joseph Sinclair<@jsync-swirlds>, Edward Wertz<@edward-swirldslabs>
 requested-by: Relay operators
 type: Standards Track
 category: Core, Service
@@ -11,24 +11,25 @@ needs-council-approval: Yes
 status: Draft
 created: 2024-11-20
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/1085
-updated: 2024-11-20
+updated: 2025-02-18
 requires: 1084
 ---
 
 ## Abstract
 
-Raises the limit on the size of `EthereumTransaction` callData to 128KB, and the limit on the total size of an
-`EthereumTransaction` from 6KB to 130KB. Introduce a new throttle bucket that represents the max bytes-per-second of
-the network, such that each node gets 1/N of that throttle bucket (using our existing throttle system). Introduce
-non-linear pricing for transactions larger than 6KB to incentivize smaller sized transactions where possible.
+This HIP raises the limit on the size of Ethereum transaction data to 128KB, and the limit on the total size of 
+Ethereum transactions from 6KB to 130KB. It introduces a new throttle bucket that represents the max bytes-per-second
+for accepting "jumbo" transactions larger than 6KB on the network, such that each node gets 1/N of the jumbo throttle 
+bucket (using our existing throttle system). This HIP also introduce non-linear pricing for transactions larger 
+than 6KB to incentivize smaller sized transactions where possible.
 
 ## Motivation
 
 Ethereum and other EVM networks permit up to 128KB of data in a call, whereas Hedera transactions can be no larger than
-6KB. Many smart contracts are much larger than 6KB and have to be broken up into multiple `FileAppend` transactions and
-use the Hedera File Service (HFS). Not only does this lead to a poor developer experience, but it makes operating a
-JSON-RPC relay difficult and expensive. By permitting transactions to use all 128KB, we improve Ethereum compatibility,
-developer experience, and make it easier to operate a JSON-RPC relay.
+6KB. Smart contracts that are larger than 6KB have to be uploaded through the Hedera File Service (HFS) through a
+`FileCreate` transaction followed by multiple `FileAppend` transactions. Not only does this lead to a poor developer
+experience, but it makes operating a JSON-RPC relay difficult and expensive. By permitting transactions to use all
+128KB, we improve Ethereum compatibility, developer experience, and make it easier to operate a JSON-RPC relay.
 
 ## Rationale
 
@@ -39,7 +40,7 @@ true when creating contracts, and for oracles sending large amounts of data to t
 
 When creating a new smart contract, if the smart contract bytecode and all other bytes for the EthereumTransaction
 (including signatures) together exceed 6KB, then the user cannot simply create a contract the way they would on Ethereum
-or other networks. They must instead use the Hedera File Service (HFS) to create a file, and then call ContractCreate
+or other networks. They must instead use the Hedera File Service (HFS) to create a file, and then call `ContractCreate`
 with that function. This has several challenges:
 
 - The workflow for Hedera is different from Ethereum and other EVM networks
@@ -50,7 +51,7 @@ with that function. This has several challenges:
   amount of data), then the user likewise must use HFS to upload the callData in chunks to a file on chain, and then
   issue an EthereumTransaction in such a way as to use that previously uploaded file as the callData.
 - Overall deployment / call latency is increased due to the need to upload files and then reference them in the
-  `EthereumTransaction`
+  Ethereum transactions.
 
 In addition, JSON-RPC relays need to find a business model whereby they can charge users for these HFS transactions.
 This creates a poor developer experience. This again breaks the business model of many cross chain relay operators and
@@ -62,21 +63,21 @@ makes access to cheap relays difficult.
    the appropriate amount of gas.
 2. As a `relay` I want to provide a service for users where they can submit and pay for transactions without increasing
    my own costs or establishing an out-of-band business model for working with users.
-  
+
 ## Specification
 
- - Permit `EthereumTransaction` callData (called `ethereum_data` in the protobuf) to be as large as 128KB
- - The entire transaction, including signatures, shall not exceed 130KB
- - Increase the price-per-byte non-linearly to encourage smaller transactions
- - Institute a network-wide throttle on bytes-per-second for "jumbo" `EthereumTransaction`s
+- Permit Ethereum transaction data to be as large as 128KB
+- The entire transaction, including signatures, shall not exceed 130KB
+- Increase the price-per-byte non-linearly to encourage smaller transactions
+- Institute a network-wide throttle on bytes-per-second for "jumbo" transactions larger than 6KB.
 
-### Services
+### Execution
 
-A new throttle bucket will be introduced that represents the max bytes-per-second of the network, such that each node
-gets 1/N of that throttle bucket (using our existing throttle system). If an `EthereumTransaction` is received that
-exceeds 6KB in size, then it is classified as a "jumbo" transaction. In addition to the normal throttle limits, the
-number of bytes exceeding 6KB will be added to the 'jumbo' throttle bucket. If the bucket does not have capacity, then
-the transaction will be rejected.
+A new configurable throttle bucket will be introduced that represents the max bytes-per-second of the network for 
+transactions larger than 6KB, such that each node gets 1/N of that throttle bucket (using our existing throttle 
+system). If any transaction received exceeds 6KB in size, then it is classified as a "jumbo" transaction. In 
+addition to the normal throttle limits, the number of bytes exceeding 6KB will be added to the 'jumbo' throttle
+bucket. If the bucket does not have capacity, then the transaction will be rejected.
 
 In addition, the price of the transaction will be increased non-linearly for transactions that exceed 6KB in size. The
 actual pricing will be determined by the Hedera Council and specified as part of the network configuration. The price
@@ -85,28 +86,36 @@ will **not** affect the gas, but **will** affect the exchange rate between gas a
 A JSON-RPC relay *should* calculate the HBAR cost of the transaction and verify the sender has sufficient funds before
 sending the transaction to the network to avoid due diligence failure fees.
 
-This HIP only designates jumbo `EthereumTransactions`. Any other transactions exceeding 6KB should be rejected.
+This HIP only permits the following Ethereum transactions to be "jumbo" transactions:
 
-The configured value for the size of an event should be set to permit at least one full-sized jumbo
-`EthereumTransaction`.
+- `EthereumTransaction` - The `ethereum_data` may be up to 128KB in size.
+- `ContractCreate` - the `initcode` may be up to 128KB in size.
+- `ContractCall` - the `functionParameters` may be up to 128KB in size.
+- `ContractCallLocal` - `functionParameters` may be up to 128KB in size.
+
+Any other transactions exceeding 6KB should be rejected unless specifically allowed by a future HIP.
+
+### Consensus
+
+The configured value for the size of an event in gossip should be set greater than one full-sized jumbo transaction.
 
 ### SDK
 
 Today, if a user wants to create a contract with a large amount of callData, they must first upload the callData to a
-file in the HFS, and then reference that file in the `EthereumTransaction`. The SDK attempts to manage this complexity
+file in the HFS, and then reference that file in Ethereum transactions. The SDK attempts to manage this complexity
 for the user automatically. With this HIP, SDKs should be updated to automatically use jumbo transactions when the
-callData exceeds 6KB. The SDK should support an option to use HFS for callData if the user prefers to manage the
-complexity themselves.
+Ethereum byte code exceeds 6KB and is less than or equal to 128KB. The SDK should support an option to use HFS for
+callData if the user prefers to manage the complexity themselves.
 
 ### Mirror Node
 
-A Mirror Node should not require any changes. While the size of the `EthereumTransaction` will be larger, and therefore
-the reason for using HFS will be lessened, the Mirror Node should be able to handle both jumbo transactions and legacy
-HFS-based `EthereumTransaction`s.
+A Mirror Node should not be impacted or require any changes. With the allowed increase in Ethereum transaction size,
+the use of HFS for Ethereum data will be lessened. The Mirror Node should be able to handle both jumbo
+Ethereum transactions and legacy HFS-based Ethereum transactions.
 
 ### Relay
 
-The JSON-RPC relay will be updated to use jumbo transactions. It will no longer use files for large callData. 
+The JSON-RPC relay will be updated to use jumbo transactions. It will no longer use files for large callData.
 
 ## Backwards Compatibility
 
@@ -125,10 +134,21 @@ maintain very small memory buffers for each connection. The consensus node shoul
 smaller buffers together when needed for jumbo transactions. This keeps memory usage minimal (vs. if every buffer was
 "jumbo" sized).
 
+Fair ordering of transactions requires that transactions are added to gossip events in the order they are
+received. Since jumbo transactions occupy more space and events are capped to a configured max size, a large number of
+consecutive jumbo transactions can cause the transaction pool in the receiving node to back up.  For this reason a 
+bytes/second throttle is necessary to limit the number of jumbo transactions received by a node per second. 
+
+Let `X` be the number of events created per second by a node. Let `E` be the configured max transaction payload per 
+event. Let `N` be the number of nodes in the network.  Let `J` be the configured jumbo transaction throttle in bytes 
+per second for the entire network.  Then the maximum throttle value allowed for a network should be 
+`J < N * (X * Floor(E / 130KB))`. Each node will be able to accept `J/N` bytes per second in jumbo transactions 
+without the possibility of a DOS attack through the event creation rate. 
+
 ## How to Teach This
 
-With this HIP, the behavior of `EthereumTransaction` will now match expectations for Ethereum developers. There should
-be documentation added to docs.hedera.com to cover `EthereumTransaction` and the documentation for the SDKs should be
+With this HIP, the behavior of Ethereum transactions will now match expectations for Ethereum developers. There should
+be documentation added to docs.hedera.com to cover this and the documentation for the SDKs should be
 updated. The main point to be described to users will be how the jumbo transactions are priced and throttled.
 
 ## References

--- a/HIP/hip-1086.md
+++ b/HIP/hip-1086.md
@@ -17,31 +17,35 @@ requires: 1084
 
 ## Abstract
 
-This HIP raises the limit on the size of Ethereum transaction data to 128KB, and the limit on the total size of 
-Ethereum transactions from 6KB to 130KB. It introduces a new throttle bucket that represents the max bytes-per-second
-for accepting "jumbo" transactions larger than 6KB on the network, such that each node gets 1/N of the jumbo throttle 
-bucket (using our existing throttle system). This HIP also introduce non-linear pricing for transactions larger 
+This HIP raises the limit on the size of Ethereum transaction `callData` to 128KB, limit on `initcode` and 
+`constructorParamaters` in `ContractCreate` to 24576 bytes each, and the limit on the total size of Ethereum 
+transactions from 6KB to 130KB. It introduces a new throttle bucket that represents the max bytes-per-second for 
+accepting "jumbo" transactions larger than 6KB on the network, such that each node gets 1/N of the jumbo throttle  
+bucket (using our existing throttle system). This HIP also introduces non-linear pricing for transactions larger  
 than 6KB to incentivize smaller sized transactions where possible.
 
 ## Motivation
 
-Ethereum and other EVM networks permit up to 128KB of data in a call, whereas Hedera transactions can be no larger than
-6KB. Smart contracts that are larger than 6KB have to be uploaded through the Hedera File Service (HFS) through a
-`FileCreate` transaction followed by multiple `FileAppend` transactions. Not only does this lead to a poor developer
-experience, but it makes operating a JSON-RPC relay difficult and expensive. By permitting transactions to use all
-128KB, we improve Ethereum compatibility, developer experience, and make it easier to operate a JSON-RPC relay.
+Ethereum and other EVM networks permit significantly larger amounts of data in a call, upto 7.15 MB of call data, 
+whereas all Hedera transactions are capped at 6KB. Smart contracts that are larger than 6KB have to be uploaded 
+through the Hedera File Service (HFS) through a `FileCreate` transaction followed by multiple `FileAppend` 
+transactions. Not only does this lead to a poor developer experience, but it makes operating a JSON-RPC relay 
+difficult and expensive. By permitting smart contracts to have 24576 bytes in `initcode` and `constructorParamaters` 
+we enable parity with Ethereum smart contract size.  Allowing contract call data upto 128KB provides parity with 
+most non-rollup use cases.  Enabling single-transaction parity with most Ethereum smart contracts and calls improves  
+compatibility, developer experience, and make it easier to operate a JSON-RPC relay.
 
 ## Rationale
 
 Hedera limits all transactions to a maximum size of 6KB. By limiting the size of transactions, Hedera makes it easier
-for clients to get fair access to the network. Ethereum, on the other hand, supports callData sizes of up to 128KB. The
-6KB limit is highly problematic for developer experience, and unexpectedly, for network efficiency. This is especially
-true when creating contracts, and for oracles sending large amounts of data to the network.
+for clients to get fair access to the network. Ethereum, on the other hand, supports much larger callData 
+sizes.The 6KB limit is highly problematic for developer experience, and unexpectedly, for network efficiency. This 
+is especially true when creating contracts, and for oracles sending large amounts of data to the network.
 
-When creating a new smart contract, if the smart contract bytecode and all other bytes for the EthereumTransaction
-(including signatures) together exceed 6KB, then the user cannot simply create a contract the way they would on Ethereum
-or other networks. They must instead use the Hedera File Service (HFS) to create a file, and then call `ContractCreate`
-with that function. This has several challenges:
+When creating a new smart contract, if the smart contract `initcode` and all other bytes for the transaction 
+(including signatures) together exceed 6KB, then the user cannot simply create a contract the way they would on 
+Ethereum or other networks. They must instead use the Hedera File Service (HFS) to create a file, and then call 
+`ContractCreate` with that function. This has several challenges:
 
 - The workflow for Hedera is different from Ethereum and other EVM networks
 - Uploading a file is expensive, and requires multiple transactions (since the file upload itself is also limited to
@@ -66,7 +70,7 @@ makes access to cheap relays difficult.
 
 ## Specification
 
-- Permit Ethereum transaction data to be as large as 128KB
+- Permit Ethereum transaction call data to be as large as 128KB
 - The entire transaction, including signatures, shall not exceed 130KB
 - Increase the price-per-byte non-linearly to encourage smaller transactions
 - Institute a network-wide throttle on bytes-per-second for "jumbo" transactions larger than 6KB.
@@ -89,23 +93,28 @@ sending the transaction to the network to avoid due diligence failure fees.
 This HIP only permits the following Ethereum transactions to be "jumbo" transactions:
 
 - `EthereumTransaction` - The `ethereum_data` may be up to 128KB in size.
-- `ContractCreate` - the `initcode` may be up to 128KB in size.
-- `ContractCall` - the `functionParameters` may be up to 128KB in size.
-- `ContractCallLocal` - `functionParameters` may be up to 128KB in size.
+- `ContractCreate` - The `initcode` and `constructorParameters` may each be up to 24576 bytes in size.
+- `ContractCall` - The `functionParameters` may be up to 128KB in size.
+- `ContractCallLocal` - The `functionParameters` may be up to 128KB in size.
 
 Any other transactions exceeding 6KB should be rejected unless specifically allowed by a future HIP.
 
 ### Consensus
 
-The configured value for the size of an event in gossip should be set greater than one full-sized jumbo transaction.
+The configured value for the size of an event in gossip should be set greater than one full-sized jumbo transaction 
+plus room for all the needed event meta data. If the max size of events prevent carrying at least 1 jumbo 
+transactions, then any node receiving a single max sized jumbo transaction have its transaction pool clogged and the 
+node will need to be restarted. This property should be checked at startup.  The node should exit if the configured 
+event size is too small.  
 
 ### SDK
 
 Today, if a user wants to create a contract with a large amount of callData, they must first upload the callData to a
 file in the HFS, and then reference that file in Ethereum transactions. The SDK attempts to manage this complexity
 for the user automatically. With this HIP, SDKs should be updated to automatically use jumbo transactions when the
-Ethereum byte code exceeds 6KB and is less than or equal to 128KB. The SDK should support an option to use HFS for
-callData if the user prefers to manage the complexity themselves.
+Ethereum byte code exceeds 6KB and is less than or equal to 128KB for call data and less than 24576 bytes for 
+`initcode` and `constructorParameters`. The SDK should support an option to use HFS for callData if the user prefers 
+to manage the complexity themselves.
 
 ### Mirror Node
 
@@ -145,6 +154,8 @@ per second for the entire network.  Then the maximum throttle value allowed for 
 `J < N * (X * Floor(E / 130KB))`. Each node will be able to accept `J/N` bytes per second in jumbo transactions 
 without the possibility of a DOS attack through the event creation rate. 
 
+The configured event size must be large enough to allow at least 1 jumbo transaction per event. 
+
 ## How to Teach This
 
 With this HIP, the behavior of Ethereum transactions will now match expectations for Ethereum developers. There should
@@ -157,6 +168,8 @@ updated. The main point to be described to users will be how the jumbo transacti
 - [Hedera JSON RPC Relay](https://docs.hedera.com/hedera/core-concepts/smart-contracts/json-rpc-relay)
 - [HIP 410](https://hips.hedera.com/hip/hip-410)
 - [HIP 1084](https://hips.hedera.com/hip/hip-1084)
+- [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860)
+- [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)
 
 ## Copyright/license
 

--- a/HIP/hip-1086.md
+++ b/HIP/hip-1086.md
@@ -27,27 +27,27 @@ than 6KB to incentivize smaller sized transactions where possible.
 ## Motivation
 
 Ethereum and other EVM networks permit significantly larger amounts of data in a call, upto 7.15 MB of call data, 
-whereas all Hedera transactions are capped at 6KB. Smart contracts that are larger than 6KB have to be uploaded 
-through the Hedera File Service (HFS) through a `FileCreate` transaction followed by multiple `FileAppend` 
+whereas all Hiero transactions are capped at 6KB. Smart contracts that are larger than 6KB have to be uploaded 
+to the Hiero File Service (HFS) through a `FileCreate` transaction followed by multiple `FileAppend` 
 transactions. Not only does this lead to a poor developer experience, but it makes operating a JSON-RPC relay 
 difficult and expensive. By permitting smart contracts to have 24576 bytes in `initcode` and `constructorParamaters` 
-we enable parity with Ethereum smart contract size.  Allowing contract call data upto 128KB provides parity with 
+we enable parity with Ethereum smart contract size.  Allowing contract call data up to 128KB provides parity with 
 most non-rollup use cases.  Enabling single-transaction parity with most Ethereum smart contracts and calls improves  
 compatibility, developer experience, and make it easier to operate a JSON-RPC relay.
 
 ## Rationale
 
-Hedera limits all transactions to a maximum size of 6KB. By limiting the size of transactions, Hedera makes it easier
+Hiero limits all transactions to a maximum size of 6KB. By limiting the size of transactions, Hiero makes it easier
 for clients to get fair access to the network. Ethereum, on the other hand, supports much larger callData 
-sizes.The 6KB limit is highly problematic for developer experience, and unexpectedly, for network efficiency. This 
+sizes. The 6KB limit is highly problematic for developer experience, and unexpectedly, for network efficiency. This 
 is especially true when creating contracts, and for oracles sending large amounts of data to the network.
 
 When creating a new smart contract, if the smart contract `initcode` and all other bytes for the transaction 
 (including signatures) together exceed 6KB, then the user cannot simply create a contract the way they would on 
-Ethereum or other networks. They must instead use the Hedera File Service (HFS) to create a file, and then call 
+Ethereum or other networks. They must instead use the Hiero File Service (HFS) to create a file, and then call 
 `ContractCreate` with that function. This has several challenges:
 
-- The workflow for Hedera is different from Ethereum and other EVM networks
+- The workflow for Hiero is different from Ethereum and other EVM networks
 - Uploading a file is expensive, and requires multiple transactions (since the file upload itself is also limited to
   6KB per transaction)
 - The file, if not deleted after use, takes up storage space needlessly
@@ -84,7 +84,7 @@ addition to the normal throttle limits, the number of bytes exceeding 6KB will b
 bucket. If the bucket does not have capacity, then the transaction will be rejected.
 
 In addition, the price of the transaction will be increased non-linearly for transactions that exceed 6KB in size. The
-actual pricing will be determined by the Hedera Council and specified as part of the network configuration. The price
+actual pricing will be determined by deployments and specified as part of the network configuration. The price
 will **not** affect the gas, but **will** affect the exchange rate between gas and USD.
 
 A JSON-RPC relay *should* calculate the HBAR cost of the transaction and verify the sender has sufficient funds before
@@ -103,9 +103,9 @@ Any other transactions exceeding 6KB should be rejected unless specifically allo
 
 The configured value for the size of an event in gossip should be set greater than one full-sized jumbo transaction 
 plus room for all the needed event meta data. If the max size of events prevent carrying at least 1 jumbo 
-transactions, then any node receiving a single max sized jumbo transaction have its transaction pool clogged and the 
-node will need to be restarted. This property should be checked at startup.  The node should exit if the configured 
-event size is too small.  
+transactions, then any node receiving a single max sized jumbo transaction will have its transaction pool clogged and 
+the node will need to be restarted. This property should be checked at startup.  The node should exit if the 
+configured event size is too small.  
 
 ### SDK
 


### PR DESCRIPTION
This PR is to update the limits in smart contract creation to match Ethereum limits. 