### PR TITLE
Block streams - update block timestamp definition

### DIFF
--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -513,12 +513,9 @@ message BlockHeader {
     bytes previous_block_hash = 4;
 
     /**
-     * A consensus timestamp for the start of this block.
-     * <p>
-     * This SHALL be the timestamp assigned by the hashgraph consensus
-     * algorithm to the first transaction of this block.
+     * A timestamp for this block.
      */
-    proto.Timestamp first_transaction_consensus_time = 5;
+    proto.Timestamp block_timestamp = 5;
 
     /**
      * The hash algorithm used in this block.
@@ -536,12 +533,13 @@ enum BlockHashAlgorithm {
     SHA2_384 = 0;
 }
 ```
+A block's timestamp is the timestamp of the first round within the block.  
 
 > Timestamp on empty round: Currently, for rounds with events and transactions, the round timestamp is equal to the
 timestamp of the last transaction in the round. For empty rounds with no events, the round timestamp is equal to the
 timestamp of the last transaction in the previous round plus 1,000 nanoseconds, rounded up to the nearest 1,000 nanoseconds.
 If there is no previous round, then the round timestamp is the median of the judge created times.
-This logic derives the value of the `BlockHeader` item `first_transaction_consensus_time` property. 
+This logic derives the value of the `BlockHeader` item `block_timestamp` property. 
 
 
 #### EventHeader

--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -513,7 +513,9 @@ message BlockHeader {
     bytes previous_block_hash = 4;
 
     /**
-     * A timestamp for this block.
+     * The timestamp for this block.<br/>
+     * The block timestamp is the consensus time stamp of the first round 
+     * in the block.
      */
     proto.Timestamp block_timestamp = 5;
 

--- a/assets/hip-1056/protobuf/stream/output/block_header.proto
+++ b/assets/hip-1056/protobuf/stream/output/block_header.proto
@@ -139,7 +139,9 @@ message BlockHeader {
     bytes previous_block_hash = 4;
 
     /**
-     * A timestamp for this block.
+     * The timestamp for this block.<br/>
+     * The block timestamp is the consensus time stamp of the first round
+     * in the block.
      * <p>
      * This SHALL be a timestamp for the block, determined as follows:<br/>
      * Given the first round within a block

--- a/assets/hip-1056/protobuf/stream/output/block_header.proto
+++ b/assets/hip-1056/protobuf/stream/output/block_header.proto
@@ -149,6 +149,8 @@ message BlockHeader {
      *   <li>If the round contains events and transactions, the
      *       timestamp SHALL be the timestamp of the last transaction in
      *       the round.</li>
+     <li>If the round has events but no transactions the timestamp
+     *      SHALL be the timestamp of the last event in the round.</li>
      *  <li>If the round contains no events or transactions, the
      *      timestamp SHALL be the timestamp of the previous round plus
      *      1000 nanoseconds.</li>

--- a/assets/hip-1056/protobuf/stream/output/block_header.proto
+++ b/assets/hip-1056/protobuf/stream/output/block_header.proto
@@ -139,12 +139,13 @@ message BlockHeader {
     bytes previous_block_hash = 4;
 
     /**
-     * A consensus timestamp for the start of this block.
+     * A timestamp for this block.
      * <p>
-     * This SHALL be the timestamp assigned by the hashgraph consensus
-     * algorithm to the first transaction of this block.
+     * This SHALL be a timestamp for the block such that the previous block's
+     * timestamp is before this timestamp and the next block's timestamp is after
+     * this timestamp.
      */
-    proto.Timestamp first_transaction_consensus_time = 5;
+    proto.Timestamp block_timestamp = 5;
 
     /**
      * A hash algorithm used for this block, including the block proof.

--- a/assets/hip-1056/protobuf/stream/output/block_header.proto
+++ b/assets/hip-1056/protobuf/stream/output/block_header.proto
@@ -141,9 +141,19 @@ message BlockHeader {
     /**
      * A timestamp for this block.
      * <p>
-     * This SHALL be a timestamp for the block such that the previous block's
-     * timestamp is before this timestamp and the next block's timestamp is after
-     * this timestamp.
+     * This SHALL be a timestamp for the block, determined as follows:<br/>
+     * Given the first round within a block
+     * <ul>
+     *   <li>If the round contains events and transactions, the
+     *       timestamp SHALL be the timestamp of the last transaction in
+     *       the round.</li>
+     *  <li>If the round contains no events or transactions, the
+     *      timestamp SHALL be the timestamp of the previous round plus
+     *      1000 nanoseconds.</li>
+     *  <li>If the round contains no events or transactions and there
+     *      is no previous round, the timestamp SHALL be the median of
+     *      the judge created timestamps for this round.</li>
+     * </ul>
      */
     proto.Timestamp block_timestamp = 5;
 


### PR DESCRIPTION
**Description**:
This PR modifies the block stream HIP to clarify the definition of the block timestamp as the consensus timestamp on the first round in the block. 
