### PR TITLE
fix: update return types for system contract calls to reflect implementation

### DIFF
--- a/HIP/hip-514.md
+++ b/HIP/hip-514.md
@@ -11,7 +11,7 @@ last-call-date-time: 2022-07-26T07:00:00Z
 release: v0.29.0
 created: 2022-06-22
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/516
-updated: 2023-02-01
+updated: 2025-07-31
 requires: 206
 ---
 
@@ -122,38 +122,38 @@ by the specific precompile function being called (see the functions below).
 
 The ABI signature and hashes for token management functions are as follows:
 
-| hash        | effective signature                                 | return                                             |
-| ------------|-----------------------------------------------------|----------------------------------------------------|
-| `927da105`  | `allowance(address, address, address)`              | `(int64, uint256)`                                 |
-| `e1f21c67`  | `approve(address, address, uint256)`                | `(int32,bool)`                                     |
-| `10585c46`  | `approveNFT(address, address, uint256)`             | `(int64)`                                          |
-| `01b2194b`  | `getApproved(address, int64)`                       | `(int32, address)`                                 |
-| `f49f40db`  | `isApprovedForAll(address, address, address)`       | `(int64, bool)`                                    |
-| `367605ca`  | `setApprovalForAll(address, address, bool)`         | `(int)`                                            |
-| `46de0fb1`  | `isFrozen(address, address)`                        | `(int32, bool)`                                    |
-| `f2c31ff4`  | `isKyc(address, address)`                           | `(int32, bool)`                                    |
-| `19f37361`  | `isToken(address)`                                  | `(int32, bool)`                                    |
-| `f069f712`  | `deleteToken(address)`                              | `(int)`                                            |
+| hash        | effective signature                                 | return                                               |
+| ------------|-----------------------------------------------------|------------------------------------------------------|
+| `927da105`  | `allowance(address, address, address)`              | `(int64, uint256)`                                   |
+| `e1f21c67`  | `approve(address, address, uint256)`                | `(int32,bool)`                                       |
+| `10585c46`  | `approveNFT(address, address, uint256)`             | `(int64)`                                            |
+| `01b2194b`  | `getApproved(address, int64)`                       | `(int32, address)`                                   |
+| `f49f40db`  | `isApprovedForAll(address, address, address)`       | `(int64, bool)`                                      |
+| `367605ca`  | `setApprovalForAll(address, address, bool)`         | `(int)`                                              |
+| `46de0fb1`  | `isFrozen(address, address)`                        | `(int32, bool)`                                      |
+| `f2c31ff4`  | `isKyc(address, address)`                           | `(int32, bool)`                                      |
+| `19f37361`  | `isToken(address)`                                  | `(int32, bool)`                                      |
+| `f069f712`  | `deleteToken(address)`                              | `(int)`                                              |
 | `ae7611a0`  | `getTokenCustomFees(address)`                       | `(int32, FixedFee[], FractionalFee[], RoyaltyFee[])` |
-| `a7daa18d`  | `getTokenDefaultFreezeStatus(address)`              | `(int32, bool)`                                    |
-| `335e04c1`  | `getTokenDefaultKycStatus(address)`                 | `(int32, bool)`                                    |
-| `d614cdb8`  | `getTokenExpiryInfo(address)`                       | `(int32, Expiry)`                                  |
-| `3f28a19b`  | `getFungibleTokenInfo(address)`                     | `(int32, FungibleTokenInfo)`                       |
-| `1f69565f`  | `getTokenInfo(address)`                             | `(int32, TokenInfo)`                               |
-| `3c4dd32e`  | `getTokenKey(address, uint)`                        | `(int32, KeyValue)`                                |
-| `93272baf`  | `getTokenType(address)`                             | `(int32, int32)`                                   |
-| `287e1da8`  | `getNonFungibleTokenInfo(address, int64)`           | `(int32, NonFungibleTokenInfo)`                    |
-| `5b8f8584`  | `freezeToken(address, address)`                     | `(int64)`                                          |
-| `52f91387`  | `unfreezeToken(address, address)`                   | `(int64)`                                          |
-| `8f8d7f99`  | `grantTokenKyc(address, address)`                   | `(int64)`                                          |
-| `af99c633`  | `revokeTokenKyc(address, address)`                  | `(int64)`                                          |
-| `7c41ad2c`  | `pauseToken(address)`                               | `(int64)`                                          |
-| `3b3bff0f`  | `unpauseToken(address)`                             | `(int64)`                                          |
-| `9790686d`  | `wipeTokenAccount(address, address, uint32)`        | `(int)`                                            |
-| `f7f38e26`  | `wipeTokenAccountNFT(address, address, int64[]])`   | `(int)`                                            |
-| `2cccc36f`  | `updateTokenInfo(address, HederaToken)`             | `(int)`                                            |
-| `593d6e82`  | `updateTokenExpiryInfo(address, Expiry)`            | `(int)`                                            |
-| `6fc3cbaf`  | `updateTokenKeys(address, uint, KeyValue)`          | `(int)`                                            |
+| `a7daa18d`  | `getTokenDefaultFreezeStatus(address)`              | `(int32, bool)`                                      |
+| `335e04c1`  | `getTokenDefaultKycStatus(address)`                 | `(int32, bool)`                                      |
+| `d614cdb8`  | `getTokenExpiryInfo(address)`                       | `(int32, Expiry)`                                    |
+| `3f28a19b`  | `getFungibleTokenInfo(address)`                     | `(int32, FungibleTokenInfo)`                         |
+| `1f69565f`  | `getTokenInfo(address)`                             | `(int32, TokenInfo)`                                 |
+| `3c4dd32e`  | `getTokenKey(address, uint)`                        | `(int32, KeyValue)`                                  |
+| `93272baf`  | `getTokenType(address)`                             | `(int32, int32)`                                     |
+| `287e1da8`  | `getNonFungibleTokenInfo(address, int64)`           | `(int32, NonFungibleTokenInfo)`                      |
+| `5b8f8584`  | `freezeToken(address, address)`                     | `(int64)`                                            |
+| `52f91387`  | `unfreezeToken(address, address)`                   | `(int64)`                                            |
+| `8f8d7f99`  | `grantTokenKyc(address, address)`                   | `(int64)`                                            |
+| `af99c633`  | `revokeTokenKyc(address, address)`                  | `(int64)`                                            |
+| `7c41ad2c`  | `pauseToken(address)`                               | `(int64)`                                            |
+| `3b3bff0f`  | `unpauseToken(address)`                             | `(int64)`                                            |
+| `9790686d`  | `wipeTokenAccount(address, address, uint32)`        | `(int)`                                              |
+| `f7f38e26`  | `wipeTokenAccountNFT(address, address, int64[]])`   | `(int)`                                              |
+| `2cccc36f`  | `updateTokenInfo(address, HederaToken)`             | `(int)`                                              |
+| `593d6e82`  | `updateTokenExpiryInfo(address, Expiry)`            | `(int)`                                              |
+| `6fc3cbaf`  | `updateTokenKeys(address, uint, KeyValue)`          | `(int)`                                              |
 
 
 ### Gas Costing


### PR DESCRIPTION
**Description**:
Many of the return types on HTS system contract functions in HIP-514 that reflect the response code do not reflect the current implementation.  Correct the return types to mismatches.
 
