### PR TITLE
HIP-1299 `account_id` updates for Address Book Node Entries.

### DIFF
--- a/HIP/hip-1299.md
+++ b/HIP/hip-1299.md
@@ -6,10 +6,11 @@ type: Standards Track
 category: Service
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Draft
+status: Last Call
+last-call-date-time: 2025-10-27T07:00:00Z
 created: 2025-09-29
-updated: 2025-10-07
-requires: HIP-869
+updated: 2025-10-13
+requires: 869
 ---
 
 ## Abstract


### PR DESCRIPTION
### Description
This proposal refines the rules for managing the account ID associated with
Node entries in the Dynamic Address Book (DAB). The DAB is a feature that
stores information about network nodes, such as their identifiers and associated
accounts, directly in the network's state instead of in Hedera File Service (
HFS) files. This makes updates more secure and consistent.

The refinements focus on how account IDs can be updated, removed, or set, with
an emphasis on security through required signatures, preventing reuse of the
same account ID across multiple nodes, and handling cases where accounts lack
sufficient funds. These changes provide flexibility for node operators while
protecting the network from disruptions.

