### PR TITLE
Update HIP-1195 with latest contract changes

### DIFF
--- a/HIP/hip-1195.md
+++ b/HIP/hip-1195.md
@@ -12,7 +12,7 @@ status: Approved
 last-call-date-time: 2025-06-06T07:00:00Z
 created: 2025-02-19
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/1172
-updated: 2025-09-17
+updated: 2025-10-03
 ---
 
 ## Abstract


### PR DESCRIPTION
Update HIP-1195 with latest contract changes. Also added a condition that account cannot be deleted with non-zero hooks