### PR TITLE
Fix draft HIP diagram rendering and add dark-theme image backdrop

### DIFF
--- a/site/scripts/build-data.js
+++ b/site/scripts/build-data.js
@@ -70,12 +70,33 @@ function extractHip(data, content, extra = {}) {
 
 // ---- Parse merged HIPs from the HIP/ directory ----
 // ---- ASCII state diagrams to replace broken image references ----
-function replaceHipImages(content) {
+// For merged HIPs, assets are copied into public/assets/ so we rewrite ../assets/ → /assets/.
+// For draft HIPs, the assets live only on the PR branch, so we rewrite to raw.githubusercontent.com
+// pinned to the PR's commit SHA. GitHub serves commits from open PR forks via the upstream repo URL.
+function replaceHipImages(content, { rawBase, availableAssets } = {}) {
   // Replace image references with placeholders (actual mermaid divs injected post-markdown in main.js)
   content = content.replace(/!\[HIP States\]\([^)]*hip-states-standards-track\.[^)]*\)/g, '<!--DIAGRAM:STANDARDS_TRACK-->');
   content = content.replace(/!\[HIP States\]\([^)]*hip-states-ipa\.[^)]*\)/g, '<!--DIAGRAM:IPA-->');
-  // Fix any remaining relative asset paths
-  content = content.replace(/\.\.\/(assets\/)/g, '/$1');
+
+  // For draft HIPs we know exactly which asset files exist in the PR. Replace
+  // markdown image references to assets that are NOT in the PR with a friendly
+  // placeholder so the page doesn't show a broken-image icon. (Common cause:
+  // author wrote ![alt](../assets/hipN/foo.png) but forgot to commit foo.png.)
+  if (availableAssets) {
+    content = content.replace(
+      /!\[([^\]]*)\]\(\s*\.\.\/(assets\/[^)\s]+)(?:\s+["'][^"']*["'])?\s*\)/g,
+      (match, alt, assetPath) => {
+        const decoded = decodeURIComponent(assetPath);
+        if (availableAssets.has(decoded)) return match;
+        const label = alt || decoded.split('/').pop();
+        return `<div class="missing-diagram"><strong>Diagram missing from PR:</strong> <code>${decoded}</code><br><span>(${label})</span></div>`;
+      }
+    );
+  }
+
+  // Rewrite remaining relative asset paths. Draft HIPs use the PR-pinned raw URL; merged HIPs use /assets/.
+  const replacement = rawBase ? `${rawBase}/assets/` : '/assets/';
+  content = content.replace(/\.\.\/assets\//g, replacement);
   return content;
 }
 
@@ -152,7 +173,13 @@ async function fetchDraftHips() {
       };
 
       hips.push(extractHip(data, parsed.content, { prNumber: pr.number }));
-      hipBodies.set(String(hipNum), replaceHipImages(parsed.content));
+      const rawBase = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${pr.headRefOid}`;
+      const availableAssets = new Set(
+        (pr.files?.edges || [])
+          .map(e => e.node.path)
+          .filter(p => p.startsWith('assets/'))
+      );
+      hipBodies.set(String(hipNum), replaceHipImages(parsed.content, { rawBase, availableAssets }));
       fetched++;
       console.log(`  PR-${pr.number}: fetched HIP-${hipNum} "${data.title}"`);
     } catch (e) {

--- a/site/src/style.css
+++ b/site/src/style.css
@@ -926,6 +926,29 @@ article table th, article table td {
 article table th { background: var(--bg-alt); font-weight: 600; }
 
 article img { max-width: 100%; height: auto; border-radius: var(--radius); }
+/* Dark-theme: most HIP diagrams are authored on white, so on the dark page they
+   either disappear (transparent PNGs) or float as a glaring white block. Wrap each
+   image in a soft off-white "paper" card with a subtle border and shadow so the
+   diagrams read as embedded artwork instead of a UI failure. */
+[data-theme="dark"] article img {
+  background: #f8fafc;
+  padding: 1.25rem;
+  box-sizing: border-box;
+  border: 1px solid #1f2937;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 4px 12px rgba(0, 0, 0, 0.25);
+  display: block;
+  margin: 1.25rem auto;
+}
+.missing-diagram {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-alt);
+  padding: 1rem 1.25rem;
+  margin: 1.25rem 0;
+  font-size: 0.9rem;
+  color: var(--text-muted, inherit);
+}
+.missing-diagram code { font-size: 0.85em; }
 article hr { border: none; border-top: 1px solid var(--border); margin: 2em 0; }
 
 /* =============================================


### PR DESCRIPTION
## Summary

Three related fixes that make HIP diagrams render correctly on hips.hedera.com.

### 1. Draft HIP assets now resolve

`site/scripts/build-data.js` was rewriting every `../assets/...` reference to `/assets/...`, which Vite serves from `public/assets/`. That directory is populated only from `main`'s checked-in assets, so any draft HIP fetched from an open PR branch had its diagrams 404. HIP-1424 (8 images) and HIP-1427 (5 images) were both affected — the issue was zero diagrams visible on either draft HIP page.

Draft bodies now rewrite to a `raw.githubusercontent.com` URL pinned to the PR's `headRefOid`. GitHub serves commits from open PR forks via the upstream repo path when addressed by commit SHA, so this works for fork-based PRs too (verified live against PR-1424 from `Nana-EC/hiero-improvement-proposal`). Merged HIPs continue to use `/assets/`.

### 2. Missing draft assets show a friendly placeholder

Authors occasionally reference an `../assets/...` path but forget to commit the file. HIP-1424 is a current example: it references `assets/hip-1424/Merkle proof sketches.png` at line 441, but that file is not in the PR's file list. There is nothing the site can fetch.

The build now cross-checks every image reference in a draft HIP against the PR's actual file list (already available in `_data/draft_hips.json`). If the file is missing, the markdown image is replaced with a dashed callout instead of a broken-image icon. The check is generic, so any draft HIP that ships with an uncommitted asset reference gets the same treatment.

### 3. Dark-theme image backdrop

Most HIP diagrams are authored on white. On the dark page they either disappeared (transparent PNGs) or floated as glaring white blocks. `[data-theme=\"dark\"] article img` now gets a soft off-white background, padding, subtle border, and drop shadow so diagrams read as embedded artwork. Light mode is untouched.

## Audit context

I scanned every `<img>` and `![](…)` reference across all 155 merged HIPs and all 13 open draft PRs while diagnosing the original report. After this PR the only outstanding broken references are upstream content gaps that need author action, not site fixes:

- **HIP-551** (`HIP/hip-551.md:119`) — references `assets/hip-551/record-stream.png`, never committed to `main`. Author needs to commit the file or remove the line.
- **HIP-1424** (PR-1424) — references `assets/hip-1424/Merkle proof sketches.png`, not in the PR. Author needs to add the file. With this PR the page no longer shows a broken-image icon for it.

## Files changed

- `site/scripts/build-data.js` — `replaceHipImages` accepts `rawBase` and `availableAssets`; draft HIP build path passes both.
- `site/src/style.css` — `[data-theme=\"dark\"] article img` card styling and `.missing-diagram` callout style.

## Test plan

- [x] Local build (`npm run build:data && npm run build` from `site/`) — succeeds, 167 HIPs built.
- [x] Verified rewritten draft URLs in `dist/data/hip-bodies.*.json` resolve `200` against `raw.githubusercontent.com` for HIP-1424 (7/8 — the 8th is the missing-asset case) and HIP-1427 (5/5).
- [x] Verified missing-asset placeholder is injected into the built body for HIP-1424's `Merkle proof sketches.png`.
- [x] Deployed the build to a fork's GitHub Pages and visually verified on https://mgarbs.github.io/hiero-improvement-proposals/#hip-1424 in both light and dark themes.
- [ ] Reviewer to confirm light-theme diagrams are unchanged on a few existing HIPs (HIP-1056, HIP-1340, HIP-1081).